### PR TITLE
Refine skills: drop ce: prefix, add initiative and side-quest

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ce:brainstorm
+name: brainstorm
 description: 'Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says ''let''s brainstorm'', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks ''what should we build'', ''help me think through X'', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don''t explicitly ask to brainstorm.'
 argument-hint: "[feature idea or problem to explore]"
 ---
@@ -8,7 +8,7 @@ argument-hint: "[feature idea or problem to explore]"
 
 **Note: The current year is 2026.** Use this when dating requirements documents.
 
-Brainstorming helps answer **WHAT** to build through collaborative dialogue. It precedes `/ce:plan`, which answers **HOW** to build it.
+Brainstorming helps answer **WHAT** to build through collaborative dialogue. It precedes `/plan`, which answers **HOW** to build it.
 
 The durable output of this workflow is a **requirements document**. In other workflows this might be called a lightweight PRD or feature brief. In compound engineering, keep the workflow name `brainstorm`, but make the written artifact strong enough that planning does not need to invent product behavior, scope boundaries, or success criteria.
 
@@ -211,8 +211,8 @@ topic: <kebab-case-topic>
 - [Affects R2][Needs research] [Question that likely requires research during planning]
 
 ## Next Steps
-[If `Resolve Before Planning` is empty: `→ /ce:plan` for structured implementation planning]
-[If `Resolve Before Planning` is not empty: `→ Resume /ce:brainstorm` to resolve blocking questions before planning]
+[If `Resolve Before Planning` is empty: `→ /plan` for structured implementation planning]
+[If `Resolve Before Planning` is not empty: `→ Resume /brainstorm` to resolve blocking questions before planning]
 ```
 
 For **Standard** and **Deep** brainstorms, a requirements document is usually warranted.
@@ -224,7 +224,7 @@ For very small requirements docs with only 1-3 simple requirements, plain bullet
 When the work is simple, combine sections rather than padding them. A short requirements document is better than a bloated one.
 
 Before finalizing, check:
-- What would `ce:plan` still have to invent if this brainstorm ended now?
+- What would `plan` still have to invent if this brainstorm ended now?
 - Do any requirements depend on something claimed to be out of scope?
 - Are any unresolved items actually product decisions rather than planning questions?
 - Did implementation details leak in when they shouldn't have?
@@ -260,7 +260,7 @@ If `Resolve Before Planning` contains any items:
 **Question when blocking questions remain and user wants to pause:** "Brainstorm paused. Planning is blocked until the remaining questions are resolved. What would you like to do next?"
 
 Present only the options that apply:
-- **Proceed to planning (Recommended)** - Run `/ce:plan` for structured implementation planning
+- **Proceed to planning (Recommended)** - Run `/plan` for structured implementation planning
 - **Proceed directly to work** - Only offer this when scope is lightweight, success criteria are clear, scope boundaries are clear, and no meaningful technical or research questions remain
 - **Review and refine** - Offer this only when a requirements document exists and can be improved through structured review
 - **Ask more questions** - Continue clarifying scope, preferences, or edge cases
@@ -273,11 +273,11 @@ If the direct-to-work gate is not satisfied, omit that option entirely.
 
 **If user selects "Proceed to planning (Recommended)":**
 
-Immediately run `/ce:plan` in the current session. Pass the requirements document path when one exists; otherwise pass a concise summary of the finalized brainstorm decisions. Do not print the closing summary first.
+Immediately run `/plan` in the current session. Pass the requirements document path when one exists; otherwise pass a concise summary of the finalized brainstorm decisions. Do not print the closing summary first.
 
 **If user selects "Proceed directly to work":**
 
-Immediately run `/ce:work` in the current session using the finalized brainstorm output as context. If a compact requirements document exists, pass its path. Do not print the closing summary first.
+Immediately run `/work` in the current session using the finalized brainstorm output as context. If a compact requirements document exists, pass its path. Do not print the closing summary first.
 
 **If user selects "Share to Proof":**
 
@@ -317,7 +317,7 @@ Key decisions:
 - [Decision 1]
 - [Decision 2]
 
-Recommended next step: `/ce:plan`
+Recommended next step: `/plan`
 ```
 
 If the user pauses with `Resolve Before Planning` still populated, display:
@@ -331,5 +331,5 @@ Planning is blocked by:
 - [Blocking question 1]
 - [Blocking question 2]
 
-Resume with `/ce:brainstorm` when ready to resolve these before planning.
+Resume with `/brainstorm` when ready to resolve these before planning.
 ```

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ce:compound
+name: compound
 description: Document a recently solved problem to compound your team's knowledge
 argument-hint: "[optional: brief context about the fix]"
 ---
@@ -17,13 +17,13 @@ Captures problem solutions while context is fresh, creating structured documenta
 ## Usage
 
 ```bash
-/ce:compound                    # Document the most recent fix
-/ce:compound [brief context]    # Provide additional context hint
+/compound                    # Document the most recent fix
+/compound [brief context]    # Provide additional context hint
 ```
 
 ## Execution Strategy
 
-**Always run full mode by default.** Proceed directly to Phase 1 unless the user explicitly requests compact-safe mode (e.g., `/ce:compound --compact` or "use compact mode").
+**Always run full mode by default.** Proceed directly to Phase 1 unless the user explicitly requests compact-safe mode (e.g., `/compound --compact` or "use compact mode").
 
 Compact-safe mode exists as a lightweight alternative — see the **Compact-Safe Mode** section below. It's there if the user wants it, not something to push.
 
@@ -119,9 +119,9 @@ The orchestrating agent (main conversation) performs these steps:
 
 After writing the new learning, decide whether this new solution is evidence that older docs should be refreshed.
 
-`ce:compound-refresh` is **not** a default follow-up. Use it selectively when the new learning suggests an older learning or pattern doc may now be inaccurate.
+`compound-refresh` is **not** a default follow-up. Use it selectively when the new learning suggests an older learning or pattern doc may now be inaccurate.
 
-It makes sense to invoke `ce:compound-refresh` when one or more of these are true:
+It makes sense to invoke `compound-refresh` when one or more of these are true:
 
 1. A related learning or pattern doc recommends an approach that the new fix now contradicts
 2. The new fix clearly supersedes an older documented solution
@@ -129,7 +129,7 @@ It makes sense to invoke `ce:compound-refresh` when one or more of these are tru
 4. A pattern doc now looks overly broad, outdated, or no longer supported by the refreshed reality
 5. The Related Docs Finder surfaced high-confidence refresh candidates in the same problem space
 
-It does **not** make sense to invoke `ce:compound-refresh` when:
+It does **not** make sense to invoke `compound-refresh` when:
 
 1. No related docs were found
 2. Related docs still appear consistent with the new learning
@@ -138,11 +138,11 @@ It does **not** make sense to invoke `ce:compound-refresh` when:
 
 Use these rules:
 
-- If there is **one obvious stale candidate**, invoke `ce:compound-refresh` with a narrow scope hint after the new learning is written
+- If there is **one obvious stale candidate**, invoke `compound-refresh` with a narrow scope hint after the new learning is written
 - If there are **multiple candidates in the same area**, ask the user whether to run a targeted refresh for that module, category, or pattern set
-- If context is already tight or you are in compact-safe mode, do not expand into a broad refresh automatically; instead recommend `ce:compound-refresh` as the next step with a scope hint
+- If context is already tight or you are in compact-safe mode, do not expand into a broad refresh automatically; instead recommend `compound-refresh` as the next step with a scope hint
 
-When invoking or recommending `ce:compound-refresh`, be explicit about the argument to pass. Prefer the narrowest useful scope:
+When invoking or recommending `compound-refresh`, be explicit about the argument to pass. Prefer the narrowest useful scope:
 
 - **Specific file** when one learning or pattern doc is the likely stale artifact
 - **Module or component name** when several related docs may need review
@@ -151,14 +151,14 @@ When invoking or recommending `ce:compound-refresh`, be explicit about the argum
 
 Examples:
 
-- `/ce:compound-refresh plugin-versioning-requirements`
-- `/ce:compound-refresh payments`
-- `/ce:compound-refresh performance-issues`
-- `/ce:compound-refresh critical-patterns`
+- `/compound-refresh plugin-versioning-requirements`
+- `/compound-refresh payments`
+- `/compound-refresh performance-issues`
+- `/compound-refresh critical-patterns`
 
 A single scope hint may still expand to multiple related docs when the change is cross-cutting within one domain, category, or pattern area.
 
-Do not invoke `ce:compound-refresh` without an argument unless the user explicitly wants a broad sweep.
+Do not invoke `compound-refresh` without an argument unless the user explicitly wants a broad sweep.
 
 Always capture the new learning first. Refresh is a targeted maintenance follow-up, not a prerequisite for documentation.
 
@@ -214,7 +214,7 @@ re-run /compound in a fresh session.
 
 **No subagents are launched. No parallel tasks. One file written.**
 
-In compact-safe mode, only suggest `ce:compound-refresh` if there is an obvious narrow refresh target. Do not broaden into a large refresh sweep from a compact-safe session.
+In compact-safe mode, only suggest `compound-refresh` if there is an obvious narrow refresh target. Do not broaden into a large refresh sweep from a compact-safe session.
 
 ---
 
@@ -324,7 +324,7 @@ Build → Test → Find Issue → Research → Improve → Document → Validate
 
 <auto_invoke> <trigger_phrases> - "that worked" - "it's fixed" - "working now" - "problem solved" </trigger_phrases>
 
-<manual_override> Use /ce:compound [context] to document immediately without waiting for auto-detection. </manual_override> </auto_invoke>
+<manual_override> Use /compound [context] to document immediately without waiting for auto-detection. </manual_override> </auto_invoke>
 
 ## Routes To
 
@@ -352,10 +352,10 @@ Based on problem type, these agents can enhance documentation:
 
 ### When to Invoke
 - **Auto-triggered** (optional): Agents can run post-documentation for enhancement
-- **Manual trigger**: User can invoke agents after /ce:compound completes for deeper review
+- **Manual trigger**: User can invoke agents after /compound completes for deeper review
 - **Customize agents**: Edit `compound-engineering.local.md` or invoke the `setup` skill to configure which review agents are used across all workflows
 
 ## Related Commands
 
 - `/research [topic]` - Deep investigation (searches docs/solutions/ for patterns)
-- `/ce:plan` - Planning workflow (references documented solutions)
+- `/plan` - Planning workflow (references documented solutions)

--- a/skills/create-initiative/SKILL.md
+++ b/skills/create-initiative/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: create-initiative
+description: Draft an initiative document from context, review it, and generate a parent issue with linked sub-tasks in GitHub
+argument-hint: "[optional framing of the initiative's goal]"
+allowed-tools: Bash, AskUserQuestion, Read, Write, TaskCreate, TaskUpdate, TaskList
+---
+
+# Create Initiative from Context
+
+Draft a markdown document proposing a parent "Initiative" and multiple "Sub-tasks" based on the current conversation, recent ideate/plan documents, and git context. After review, automatically create them in GitHub and link them together.
+
+## Progress Tracking
+
+Before starting, use `TaskList` to clear old tasks. Then create:
+1. "Gather context and draft initiative document" (activeForm: "Drafting...")
+2. "Review with user" (activeForm: "Waiting for review...")
+3. "Fetch GitHub metadata" (activeForm: "Fetching metadata...")
+4. "Create parent issue in GitHub" (activeForm: "Creating initiative...")
+5. "Create sub-tasks and link" (activeForm: "Creating child issues...")
+6. "Add to project" (activeForm: "Adding to project...")
+
+## Phase 1: Gather Context & Draft Document
+
+1. **Gather context:** Combine the user argument, conversation history, recent markdown documents (`docs/brainstorms/`, `docs/plans/`, `docs/ideate/`), and recent git signals (`git status`, `git diff`, `git log`).
+2. **Structure the Initiative:** Identify the overarching goal (Parent Issue) and break it down into logical, deliverable chunks (Sub-tasks).
+3. **Create the Document:**
+   - Ensure the `docs/initiatives/` directory exists. If creating the directory for the first time, ensure `docs/initiatives/` is added to the project's `.gitignore` file.
+   - Determine filename: `docs/initiatives/YYYY-MM-DD-NNN-<kebab-case-topic>.md` (check existing files for today's date to determine the zero-padded next sequence number).
+   - Write the document using the template from [initiative-template.md](initiative-template.md).
+   - Note that the bodies of the subtasks and parent issue should loosely follow the structure in [initiative-issue-template.md](initiative-issue-template.md).
+
+## Phase 2: Review
+
+1. Inform the user the document has been written to `docs/initiatives/<filename>`.
+2. Use `AskUserQuestion` to ask: "Initiative drafted at `docs/initiatives/<filename>`. Ready to create the issues in GitHub, or do you want to revise the document first?"
+   - Options:
+     - **Create Issues** (description: "Proceed to Phase 3")
+     - **Revise Document** (description: "Type feedback in 'Other' to regenerate, or manually edit the file first")
+     - **Cancel** (description: "Abort without creating")
+   - If user cancels, stop.
+   - If user provides custom input via Other, treat it as revision notes, regenerate the document, and re-ask.
+   - **Crucial:** Wait for the user to confirm "Create Issues" before proceeding. The user may manually edit the document in their IDE during this time.
+
+## Phase 3: GitHub Execution
+
+1. **Detect Repository & Auth:**
+   - Run `git remote get-url origin` to parse `<owner>/<repo>`.
+   - Verify `gh auth status`.
+2. **Fetch Metadata & Prompt for Labels/Types:**
+   - Fetch labels and issue types in parallel:
+     ```bash
+     gh label list --repo <owner>/<repo> --json name,description --limit 100
+     ```
+     ```bash
+     gh api graphql -f query='
+     {
+       repository(owner: "<owner>", name: "<repo>") {
+         issueTypes(first: 20) {
+           nodes { id name description }
+         }
+       }
+     }'
+     ```
+   - Use `AskUserQuestion` to prompt the user:
+     - **Parent Issue:** The label is automatically set to `initiative`. Ask the user for the **Issue Type** for the parent issue.
+     - **Sub-tasks:** Ask the user to select the **Label** and **Issue Type** for the sub-tasks. (You may ask for them individually or sequentially).
+3. **Read Final Document:**
+   - Read the finalized markdown document using the `Read` tool to ensure any manual edits by the user are captured.
+4. **Create Parent Issue:**
+   - Use `gh issue create` to create the Parent issue with the `initiative` label.
+   - Capture its issue number (e.g., `#100`) from the output.
+   - Set the issue type via GraphQL using the ID fetched earlier.
+5. **Create Sub-tasks:**
+   - Loop through each Sub-task in the document.
+   - Use `gh issue create` for each, using the label(s) specified by the user. Include a reference to the parent in the body: `Part of #<parent_issue_number>\n\n<Description>`.
+   - Capture each sub-task's issue number (e.g., `#101`, `#102`).
+   - Set the issue type for each via GraphQL.
+6. **Link via Task List:**
+   - Update the Parent issue to include a GitHub task list of the child issues.
+   - Fetch the current body of the parent, append `\n\n### Sub-tasks\n- [ ] #<child_1>\n- [ ] #<child_2>`, and update it using `gh issue edit <parent_number> --body ...`.
+7. **Update Document:**
+   - Update the `docs/initiatives/` markdown document:
+     - Change `status: drafted` to `status: created`.
+     - Set `github_issue: #<parent_issue_number>`.
+
+## Phase 4: Add to Project
+
+1. Fetch projects live:
+   ```bash
+   gh project list --owner <owner> --format json --limit 20
+   ```
+2. If projects exist, use `AskUserQuestion` to prompt:
+   > "Select a project to add this initiative to:"
+   - Show available projects. 
+   - Do NOT include a "Skip" option - this step is mandatory if projects are found.
+3. Add the **Parent Issue** to the selected project using `gh project item-add`.
+   ```bash
+   gh project item-add <project-number> \
+     --owner <owner> \
+     --url "$(gh issue view <issue-number> --repo <owner>/<repo> --json url --jq .url)"
+   ```
+   - Note: If there are errors, report them but proceed.
+
+## Phase 5: Output
+- Output a clean summary with the URL to the Parent Issue and a list of all Sub-tasks created.

--- a/skills/create-initiative/initiative-issue-template.md
+++ b/skills/create-initiative/initiative-issue-template.md
@@ -1,0 +1,13 @@
+### Summary
+- <1-3 bullets describing the sub-task or initiative goal>
+
+### Evidence / Context
+- <key observations from git diff/log and context>
+- <Reference to parent initiative>
+
+### Expected Outcomes
+- <intended behavior / outcome>
+
+### Technical Notes
+- <pointers, constraints, or relevant files>
+- <Repro steps, if applicable>

--- a/skills/create-initiative/initiative-template.md
+++ b/skills/create-initiative/initiative-template.md
@@ -1,0 +1,25 @@
+---
+date: YYYY-MM-DD
+topic: <kebab-case-topic>
+status: drafted
+github_issue: 
+---
+
+# Initiative: <Title>
+
+## Context & Goals
+[Why are we doing this? What is the overarching goal?]
+
+## Parent Issue
+**Title:** <Title>
+**Description:**
+[High-level description of the initiative. This will become the body of the Parent Issue.]
+
+## Sub-Tasks
+### 1. <Sub-task 1 Title>
+**Description:** [What needs to be done. This will become the body of the Child Issue.]
+**Technical Notes:** [Any specific pointers or constraints]
+
+### 2. <Sub-task 2 Title>
+**Description:** [What needs to be done. This will become the body of the Child Issue.]
+**Technical Notes:** [Any specific pointers or constraints]

--- a/skills/deepen-plan/SKILL.md
+++ b/skills/deepen-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[path to plan file]"
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.
 
-`ce:plan` does the first planning pass. `deepen-plan` is a second-pass confidence check.
+`plan` does the first planning pass. `deepen-plan` is a second-pass confidence check.
 
 Use this skill when the plan already exists and the question is not "Is this document clear?" but rather "Is this plan grounded enough for the complexity and risk involved?"
 
@@ -43,7 +43,7 @@ Do not proceed until you have a valid plan file path.
 3. **Prefer the simplest execution mode** - Use direct agent synthesis by default. Switch to artifact-backed research only when the selected research scope is large enough that returning all findings inline would create avoidable context pressure.
 4. **Preserve the planning boundary** - No implementation code, no git command choreography, no exact test command recipes.
 5. **Use artifact-contained evidence** - Work from the written plan, its `Context & Research`, `Sources & References`, and its origin document when present.
-6. **Respect product boundaries** - Do not invent new product requirements. If deepening reveals a product-level gap, surface it as an open question or route back to `ce:brainstorm`.
+6. **Respect product boundaries** - Do not invent new product requirements. If deepening reveals a product-level gap, surface it as an open question or route back to `brainstorm`.
 7. **Prioritize risk and cross-cutting impact** - The more dangerous or interconnected the work, the more valuable another planning pass becomes.
 
 ## Workflow
@@ -83,10 +83,10 @@ Use this default:
 
 If the plan already appears sufficiently grounded:
 - Say so briefly
-- Recommend moving to `/ce:work` or the `document-review` skill
+- Recommend moving to `/work` or the `document-review` skill
 - If the user explicitly asked to deepen anyway, continue with a light pass and deepen at most 1-2 sections
 
-### Phase 1: Parse the Current `ce:plan` Structure
+### Phase 1: Parse the Current `plan` Structure
 
 Map the plan into the current template. Look for these sections, or their nearest equivalents:
 - `Overview`
@@ -363,7 +363,7 @@ Do **not**:
 If research reveals a product-level ambiguity that should change behavior or scope:
 - Do not silently decide it here
 - Record it under `Open Questions`
-- Recommend `ce:brainstorm` if the gap is truly product-defining
+- Recommend `brainstorm` if the gap is truly product-defining
 
 ### Phase 6: Final Checks and Write the File
 
@@ -393,17 +393,17 @@ If substantive changes were made, present next steps using the platform's blocki
 **Options:**
 1. **View diff** - Show what changed
 2. **Run `document-review` skill** - Improve the updated plan through structured document review
-3. **Start `ce:work` skill** - Begin implementing the plan
+3. **Start `work` skill** - Begin implementing the plan
 4. **Deepen specific sections further** - Run another targeted deepening pass on named sections
 
 Based on selection:
 - **View diff** -> Show the important additions and changed sections
 - **`document-review` skill** -> Load the `document-review` skill with the plan path
-- **Start `ce:work` skill** -> Call the `ce:work` skill with the plan path
+- **Start `work` skill** -> Call the `work` skill with the plan path
 - **Deepen specific sections further** -> Ask which sections still feel weak and run another targeted pass only for those sections
 
 If no substantive changes were warranted:
 - Say that the plan already appears sufficiently grounded
-- Offer the `document-review` skill or `/ce:work` as the next step instead
+- Offer the `document-review` skill or `/work` as the next step instead
 
 NEVER CODE! Research, challenge, and strengthen the plan.

--- a/skills/git-worktree/SKILL.md
+++ b/skills/git-worktree/SKILL.md
@@ -42,8 +42,8 @@ git worktree add .worktrees/feature-name -b feature-name main
 
 Use this skill in these scenarios:
 
-1. **Code Review (`/ce:review`)**: If NOT already on the target branch (PR branch or requested branch), offer worktree for isolated review
-2. **Feature Work (`/ce:work`)**: Always ask if user wants parallel worktree or live branch work
+1. **Code Review (`/review`)**: If NOT already on the target branch (PR branch or requested branch), offer worktree for isolated review
+2. **Feature Work (`/work`)**: Always ask if user wants parallel worktree or live branch work
 3. **Parallel Development**: When working on multiple features simultaneously
 4. **Cleanup**: After completing work in a worktree
 
@@ -51,7 +51,7 @@ Use this skill in these scenarios:
 
 ### In Claude Code Workflows
 
-The skill is automatically called from `/ce:review` and `/ce:work` commands:
+The skill is automatically called from `/review` and `/work` commands:
 
 ```
 # For review: offers worktree if not on PR branch
@@ -212,7 +212,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree-manager.sh clean
 
 ## Integration with Workflows
 
-### `/ce:review`
+### `/review`
 
 Instead of always creating a worktree:
 
@@ -225,7 +225,7 @@ Instead of always creating a worktree:
    - no → proceed with PR diff on current branch
 ```
 
-### `/ce:work`
+### `/work`
 
 Always offer choice:
 

--- a/skills/ideate/SKILL.md
+++ b/skills/ideate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ce:ideate
+name: ideate
 description: "Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea."
 argument-hint: "[optional: feature, focus area, or constraint]"
 ---
@@ -8,11 +8,11 @@ argument-hint: "[optional: feature, focus area, or constraint]"
 
 **Note: The current year is 2026.** Use this when dating ideation documents and checking recent ideation artifacts.
 
-`ce:ideate` precedes `ce:brainstorm`.
+`ideate` precedes `brainstorm`.
 
-- `ce:ideate` answers: "What are the strongest ideas worth exploring?"
-- `ce:brainstorm` answers: "What exactly should one chosen idea mean?"
-- `ce:plan` answers: "How should it be built?"
+- `ideate` answers: "What are the strongest ideas worth exploring?"
+- `brainstorm` answers: "What exactly should one chosen idea mean?"
+- `plan` answers: "How should it be built?"
 
 This workflow produces a ranked ideation artifact in `docs/ideation/`. It does **not** produce requirements, plans, or code.
 
@@ -43,7 +43,7 @@ If no argument is provided, proceed with open-ended ideation.
 4. **Preserve the original prompt mechanism** - Generate many ideas, critique the whole list, then explain only the survivors in detail. Do not let extra process obscure this pattern.
 5. **Use agent diversity to improve the candidate pool** - Parallel sub-agents are a support mechanism for richer idea generation and critique, not the core workflow itself.
 6. **Preserve the artifact early** - Write the ideation document before presenting results so work survives interruptions.
-7. **Route action into brainstorming** - Ideation identifies promising directions; `ce:brainstorm` defines the selected one precisely enough for planning.
+7. **Route action into brainstorming** - Ideation identifies promising directions; `brainstorm` defines the selected one precisely enough for planning.
 
 ## Execution Flow
 
@@ -252,14 +252,14 @@ Allow brief follow-up questions and lightweight clarification before writing the
 Do not write the ideation doc yet unless:
 - the user indicates the candidate set is good enough to preserve
 - the user asks to refine and continue in a way that should be recorded
-- the workflow is about to hand off to `ce:brainstorm`, Proof sharing, or session end
+- the workflow is about to hand off to `brainstorm`, Proof sharing, or session end
 
 ### Phase 5: Write the Ideation Artifact
 
 Write the ideation artifact after the candidate set has been reviewed enough to preserve.
 
 Always write or update the artifact before:
-- handing off to `ce:brainstorm`
+- handing off to `brainstorm`
 - sharing to Proof
 - ending the session
 
@@ -326,7 +326,7 @@ If the user selects an idea:
 - write or update the ideation doc first
 - mark that idea as `Explored`
 - note the brainstorm date in the session log
-- invoke `ce:brainstorm` with the selected idea as the seed
+- invoke `brainstorm` with the selected idea as the seed
 
 Do **not** skip brainstorming and go straight to planning from ideation output.
 
@@ -367,4 +367,4 @@ Before finishing, check:
 - every rejected idea has a reason
 - survivors are materially better than a naive "give me ideas" list
 - the artifact was written before any handoff, sharing, or session end
-- acting on an idea routes to `ce:brainstorm`, not directly to implementation
+- acting on an idea routes to `brainstorm`, not directly to implementation

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: ce:plan
-description: "Transform feature descriptions or requirements into structured implementation plans grounded in repo patterns and research. Use when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', or when a brainstorm/requirements document is ready for technical planning. Best when requirements are at least roughly defined; for exploratory or ambiguous requests, prefer ce:brainstorm first."
+name: plan
+description: "Transform feature descriptions or requirements into structured implementation plans grounded in repo patterns and research. Use when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', or when a brainstorm/requirements document is ready for technical planning. Best when requirements are at least roughly defined; for exploratory or ambiguous requests, prefer brainstorm first."
 argument-hint: "[feature description, requirements doc path, or improvement idea]"
 ---
 
@@ -8,9 +8,9 @@ argument-hint: "[feature description, requirements doc path, or improvement idea
 
 **Note: The current year is 2026.** Use this when dating plans and searching for recent documentation.
 
-`ce:brainstorm` defines **WHAT** to build. `ce:plan` defines **HOW** to build it. `ce:work` executes the plan.
+`brainstorm` defines **WHAT** to build. `plan` defines **HOW** to build it. `work` executes the plan.
 
-This workflow produces a durable implementation plan. It does **not** implement code, run tests, or learn from execution-time results. If the answer depends on changing code and seeing what happens, that belongs in `ce:work`, not here.
+This workflow produces a durable implementation plan. It does **not** implement code, run tests, or learn from execution-time results. If the answer depends on changing code and seeing what happens, that belongs in `work`, not here.
 
 ## Interaction Method
 
@@ -28,7 +28,7 @@ Do not proceed until you have a clear planning input.
 
 ## Core Principles
 
-1. **Use requirements as the source of truth** - If `ce:brainstorm` produced a requirements document, planning should build from it rather than re-inventing behavior.
+1. **Use requirements as the source of truth** - If `brainstorm` produced a requirements document, planning should build from it rather than re-inventing behavior.
 2. **Decisions, not code** - Capture approach, boundaries, files, dependencies, risks, and test scenarios. Do not pre-write implementation code or shell command choreography. Pseudo-code sketches or DSL grammars that communicate high-level technical design are welcome when they help a reviewer validate direction — but they must be explicitly framed as directional guidance, not implementation specification.
 3. **Research before structuring** - Explore the codebase, institutional learnings, and external guidance when warranted before finalizing the plan.
 4. **Right-size the artifact** - Small work gets a compact plan. Large work gets more structure. The philosophy stays the same at every depth.
@@ -94,7 +94,7 @@ If no relevant requirements document exists, planning may proceed from the user'
 
 If no relevant requirements document exists:
 - Assess whether the request is already clear enough for direct technical planning
-- If the ambiguity is mainly product framing, user behavior, or scope definition, recommend `ce:brainstorm` first
+- If the ambiguity is mainly product framing, user behavior, or scope definition, recommend `brainstorm` first
 - If the user wants to continue here anyway, run a short planning bootstrap instead of refusing
 
 The planning bootstrap should establish:
@@ -107,7 +107,7 @@ The planning bootstrap should establish:
 Keep this bootstrap brief. It exists to preserve direct-entry convenience, not to replace a full brainstorm.
 
 If the bootstrap uncovers major unresolved product questions:
-- Recommend `ce:brainstorm` again
+- Recommend `brainstorm` again
 - If the user still wants to continue, require explicit assumptions before proceeding
 
 #### 0.5 Classify Outstanding Questions Before Planning
@@ -120,7 +120,7 @@ If the origin document contains `Resolve Before Planning` or similar blocking qu
 If true product blockers remain:
 - Surface them clearly
 - Ask the user, using the platform's blocking question tool when available (see Interaction Method), whether to:
-  1. Resume `ce:brainstorm` to resolve them
+  1. Resume `brainstorm` to resolve them
   2. Convert them into explicit assumptions or decisions and continue
 - Do not continue planning while true blockers remain unresolved
 
@@ -554,7 +554,7 @@ For larger `Deep` plans, extend the core template only when useful with sections
 #### 5.1 Review Before Writing
 
 Before finalizing, check:
-- The plan does not invent product behavior that should have been defined in `ce:brainstorm`
+- The plan does not invent product behavior that should have been defined in `brainstorm`
 - If there was no origin document, the bounded planning bootstrap established enough product clarity to plan responsibly
 - Every major decision is grounded in the origin document or research
 - Each implementation unit is concrete, dependency-ordered, and implementation-ready
@@ -567,7 +567,7 @@ Before finalizing, check:
 If the plan originated from a requirements document, re-read that document and verify:
 - The chosen approach still matches the product intent
 - Scope boundaries and success criteria are preserved
-- Blocking questions were either resolved, explicitly assumed, or sent back to `ce:brainstorm`
+- Blocking questions were either resolved, explicitly assumed, or sent back to `brainstorm`
 - Every section of the origin document is addressed in the plan — scan each section to confirm nothing was silently dropped
 
 #### 5.2 Write Plan File
@@ -599,8 +599,8 @@ After writing the plan file, present the options using the platform's blocking q
 2. **Run `/deepen-plan`** - Stress-test weak sections with targeted research when the plan needs more confidence
 3. **Run `document-review` skill** - Improve the plan through structured document review
 4. **Share to Proof** - Upload the plan for collaborative review and sharing
-5. **Start `/ce:work`** - Begin implementing this plan in the current environment
-6. **Start `/ce:work` in another session** - Begin implementing in a separate agent session when the current platform supports it
+5. **Start `/work`** - Begin implementing this plan in the current environment
+6. **Start `/work` in another session** - Begin implementing in a separate agent session when the current platform supports it
 7. **Create Issue** - Create an issue in the configured tracker
 
 Based on selection:
@@ -617,8 +617,8 @@ Based on selection:
   PROOF_URL=$(echo "$RESPONSE" | jq -r '.tokenUrl')
   ```
   Display `View & collaborate in Proof: <PROOF_URL>` if successful, then return to the options
-- **`/ce:work`** → Call `/ce:work` with the plan path
-- **`/ce:work` in another session** → If the current platform supports launching a separate agent session, start `/ce:work` with the plan path there. Otherwise, explain the limitation briefly and offer to run `/ce:work` in the current session instead.
+- **`/work`** → Call `/work` with the plan path
+- **`/work` in another session** → If the current platform supports launching a separate agent session, start `/work` with the plan path there. Otherwise, explain the limitation briefly and offer to run `/work` in the current session instead.
 - **Create Issue** → Follow the Issue Creation section below
 - **Other** → Accept free text for revisions and loop back to options
 
@@ -647,6 +647,6 @@ When the user selects "Create Issue", detect their project tracker from `AGENTS.
 
 After issue creation:
 - Display the issue URL
-- Ask whether to proceed to `/ce:work`
+- Ask whether to proceed to `/work`
 
 NEVER CODE! Research, decide, and write the plan.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ce:review
+name: review
 description: Perform exhaustive code reviews using multi-agent analysis, ultra-thinking, and worktrees
 argument-hint: "[PR number, GitHub URL, branch name, or latest] [--serial]"
 ---
@@ -53,8 +53,8 @@ Ensure that the code is ready for analysis (either in worktree or on current bra
 <protected_artifacts>
 The following paths are compound-engineering pipeline artifacts and must never be flagged for deletion, removal, or gitignore by any review agent:
 
-- `docs/brainstorms/*-requirements.md` — Requirements documents created by `/ce:brainstorm`. These are the product-definition artifacts that planning depends on.
-- `docs/plans/*.md` — Plan files created by `/ce:plan`. These are living documents that track implementation progress (checkboxes are checked off by `/ce:work`).
+- `docs/brainstorms/*-requirements.md` — Requirements documents created by `/brainstorm`. These are the product-definition artifacts that planning depends on.
+- `docs/plans/*.md` — Plan files created by `/plan`. These are living documents that track implementation progress (checkboxes are checked off by `/work`).
 - `docs/solutions/*.md` — Solution documents created during the pipeline.
 
 If a review agent flags any file in these directories for cleanup or removal, discard that finding during synthesis. Do not create a todo for it.

--- a/skills/side-quest/SKILL.md
+++ b/skills/side-quest/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: side-quest
+description: 'Document out-of-scope tasks, technical debt, or related ideas discovered during execution that should be tracked but not immediately addressed. Ties the side-quest to the current issue.'
+argument-hint: "[brief description of the side quest or task]"
+---
+
+# Document a Side-Quest
+
+**Note: The current year is 2026.** Use this when dating documents.
+
+`side-quest` captures tasks, tech debt, or improvements discovered while working on a primary issue. It ensures these items are documented safely without derailing the current context.
+
+## Core Principles
+
+1. **Keep it focused** - Document just enough context so you (or someone else) can pick it up later.
+2. **Tie to a source of truth** - Every side-quest should reference the original issue it spawned from. If you can tie to a brainstorm, ideate, and/or plan document, do that too. 
+3. **Don't fix it now** - The goal of this skill is to unload the mental burden so execution can continue on the main task.
+
+## Interaction Flow
+
+<side_quest_description> #$ARGUMENTS </side_quest_description>
+
+**If the side-quest description above is empty, ask the user:** "What side-quest or technical debt did you discover? Please provide a brief description."
+
+### Context Gathering
+1. Check the current git branch by running `git rev-parse --abbrev-ref HEAD`.
+2. Extract the issue number from the branch name. The project's branch naming convention is `{prefix}/{issue-number}/{short-description}` (e.g., `feat/123/add-login` -> `123`).
+3. If an issue number is successfully extracted, use it automatically.
+4. If the branch does not contain a clear issue number and it wasn't provided in the prompt, ask the user: "What is the GitHub/Linear issue number this relates to?"
+5. Scan `docs/brainstorms/`, `docs/plans/`, or `docs/ideate/` for any recent documents that relate to this issue or current context.
+
+## Phase 1: Structure the Document
+
+### Title and File Naming
+
+- Draft a concise, searchable title for the side-quest.
+- Build the filename following this convention: `docs/side-quests/YYYY-MM-DD-NNN-issue-[number]-[kebab-case-topic].md`
+  - Create `docs/side-quests/` if it does not exist.
+  - If creating the directory for the first time, ensure `docs/side-quests/` is added to the project's `.gitignore` file.
+  - Check existing files for today's date to determine the next sequence number (zero-padded to 3 digits, starting at 001).
+  - Include the issue number (e.g., `issue-123`).
+  - Example: `2026-04-06-001-issue-42-fix-pagination-edge-case.md`
+
+### Document Template
+
+Use the following template for the side-quest document:
+
+```markdown
+---
+date: YYYY-MM-DD
+issue: #[number]
+branch: <current-branch-name>
+topic: <kebab-case-topic>
+status: pending
+---
+
+# <Topic Title>
+
+## Discovery Context
+[How was this discovered? What were we working on (Issue #[number]) when this came up?]
+
+**Related Documents:**
+- [Path to related brainstorm, plan, or ideate document if found]
+
+## Description
+[Clear description of the task, bug, or technical debt.]
+
+## Impact / Why it matters
+[Why should we fix this later? What happens if we don't?]
+
+## Implementation Pointers
+- **Relevant files:** [List any files, functions, or line numbers involved]
+- **Potential approach:** [Brief note on how to solve it, if known]
+```
+
+## Phase 2: Write the File
+
+Use the Write tool to save the side-quest document to the path determined in Phase 1.
+
+Confirm to the user:
+```text
+Side-quest documented at `docs/side-quests/[filename]`.
+```
+
+## Phase 3: Next Steps
+
+Ask the user: "Side-quest saved. Ready to return to your main task?"

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ce:work
+name: work
 description: Execute work plans efficiently while maintaining quality and finishing features
 argument-hint: "[plan file, specification, or todo file path]"
 ---


### PR DESCRIPTION
### Related Issue
HagenFritz/cc-forge#6

### Primary Changes
- 🏷️ **Drop `ce:` prefix from skill names:** Renames all 8 core skills (brainstorm, compound, deepen-plan, git-worktree, ideate, plan, review, work) and updates all cross-references to use shorter `/brainstorm`, `/plan`, `/work` invocations
- 🔧 **Refine branch skill:** UX improvements and guardrails for the `/branch` command
- 📝 **Improve create-issue-from-context:** Task cleanup and issue preview enhancements

### Related Changes
- ✨ **Add create-initiative skill:** Workflow for drafting initiative documents with parent/child GitHub issue structure, interactive review, and project board integration
- ✨ **Add side-quest skill:** Quick capture for tech debt, related ideas, or off-track tasks discovered during execution without losing focus on the primary issue

---

### Test Plan
- [ ] Verify skills are invocable without `ce:` prefix (e.g., `/brainstorm`, `/plan`, `/work`)
- [ ] Verify cross-references within skill files point to renamed commands
- [ ] Test `/create-initiative` drafts a document and creates linked GitHub issues
- [ ] Test `/side-quest` captures a side-quest document tied to the current branch issue

Generated with [Claude Code](https://claude.com/claude-code)