### PR TITLE
Skill improvements and install pruning

### DIFF
--- a/skills/branch/SKILL.md
+++ b/skills/branch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: branch
-description: Create and checkout a new branch from an issue number
+description: Create and checkout a new branch from an issue number or conversation context
 disable-model-invocation: true
 user-invocable: true
-argument-hint: <issue-number>
+argument-hint: "[issue-number]"
 allowed-tools: Bash, AskUserQuestion, TaskCreate, TaskUpdate, TaskList, Skill
 ---
 
-Create and checkout a new git branch following the naming convention: `{prefix}/{issue-number}/{short-description}`
+Create and checkout a new git branch following the naming convention: `{prefix}/{issue-number}/{short-description}` (or `{prefix}/{short-description}` when no issue number is available).
 
 ## Progress Tracking
 
@@ -15,7 +15,7 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
 
 1. "Check current branch" (activeForm: "Checking branch...")
 2. "Sync with remote" (activeForm: "Syncing...")
-3. "Fetch issue details" (activeForm: "Fetching issue...")
+3. "Resolve branch context" (activeForm: "Resolving context...")
 4. "Construct branch name" (activeForm: "Building branch name...")
 5. "Create and checkout branch" (activeForm: "Checking out...")
 
@@ -34,16 +34,11 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
    - Run `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null` to check if the current branch has an upstream. If it errors or returns nothing, skip this step.
    - If upstream exists, run `git pull`.
 
-3. **Parse the argument.** `$ARGUMENTS` is the issue number.
-   - If no argument is provided or it's empty, STOP and tell the user:
-     > "An issue number is required. Usage: /branch <issue-number>"
+3. **Resolve branch context.** `$ARGUMENTS` may or may not contain an issue number.
+   - **If an issue number is provided:** detect `<owner>/<repo>` from `git remote get-url origin`, then run `gh issue view $ARGUMENTS --repo <owner>/<repo>` to get the issue title and description. Use this to determine the **prefix** and **short description**.
+   - **If no argument is provided:** derive the **prefix** and **short description** from conversation context (what the user is working on, recent discussion, file changes, etc.). The branch name will use the format `{prefix}/{short-description}` (no issue number segment). Skip step 11 (no issue comment to post).
 
-4. **Fetch the issue.**
-   - Detect `<owner>/<repo>` from `git remote get-url origin`.
-   - Run `gh issue view $ARGUMENTS --repo <owner>/<repo>` to get the issue title and description.
-   - Use this to determine the **prefix** and **short description** (2–4 words, kebab-case).
-
-5. **Determine the prefix** based on the nature of the work:
+4. **Determine the prefix** based on the nature of the work:
    - `feat/` — new feature or enhancement
    - `bugfix/` — non-urgent bug fix
    - `hotfix/` — urgent production fix
@@ -52,9 +47,10 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
    - `test/` — adding or updating tests
    - `docs/` — documentation only
 
-6. **Construct the branch name:** `{prefix}/{issue-number}/{short-description}`
+6. **Construct the branch name:**
+   - With issue: `{prefix}/{issue-number}/{short-description}` (e.g. `feat/171/committed-actions`)
+   - Without issue: `{prefix}/{short-description}` (e.g. `feat/read-issue-auto-repo`)
    - The description must be 2–4 words, lowercase, hyphen-separated
-   - Example: `feat/171/committed-actions`
 
 7. **Check for stale branch.**
    - Run `git branch --list {branch-name}` to see if a branch with that name already exists locally.
@@ -80,7 +76,7 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
 10. **Rename the session** to match the branch name using the `/rename` built-in command:
     - Invoke `/rename {branch-name}` so the session is identifiable when resuming later.
 
-11. **Post a comment on the GitHub issue** with the branch name:
+11. **Post a comment on the GitHub issue** (only if an issue number was provided):
     ```bash
     gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "Branch created: \`{branch-name}\`"
     ```

--- a/skills/read-issue/SKILL.md
+++ b/skills/read-issue/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: read-issue
-description: Fetch a GitHub issue from ro-compass-web by number and present a structured digest
+description: Fetch a GitHub issue from the current repo by number and present a structured digest
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "<issue-number>"
 allowed-tools: Bash
 ---
 
-Fetch a GitHub issue from the `rogers-obrien-rad/ro-compass-web` repo and present a structured, easy-to-scan digest.
+Fetch a GitHub issue from the current repository and present a structured, easy-to-scan digest.
 
 ## Steps
 
@@ -15,12 +15,18 @@ Fetch a GitHub issue from the `rogers-obrien-rad/ro-compass-web` repo and presen
    - The argument is the issue number (e.g., `564`).
    - If no argument is provided, STOP and ask the user for an issue number.
 
-2. **Fetch the issue.**
+2. **Detect the current repo.**
    ```bash
-   gh issue view <issue-number> --repo rogers-obrien-rad/ro-compass-web --json title,body,labels,assignees,state,milestone,comments
+   gh repo view --json nameWithOwner -q .nameWithOwner
+   ```
+   - If the command fails (not a GitHub repo or no remote), STOP and report the error clearly.
+
+3. **Fetch the issue.**
+   ```bash
+   gh issue view <issue-number> --repo <detected-repo> --json title,body,labels,assignees,state,milestone,comments
    ```
 
-3. **Present a digest** with this structure:
+4. **Present a digest** with this structure:
    - **Title** (as a heading)
    - **Metadata line:** Status | Assigned to | Labels | Milestone (if any) | Blocked by (if mentioned)
    - **What:** 1-3 sentence plain-language summary of the issue
@@ -29,9 +35,9 @@ Fetch a GitHub issue from the `rogers-obrien-rad/ro-compass-web` repo and presen
    - **Expected outcome:** What "done" looks like
    - **Comments:** Summarize any comments if present; omit section if none
 
-4. **Keep it concise.** The digest should be scannable in under 30 seconds. Don't parrot the issue body verbatim — synthesize it.
+5. **Keep it concise.** The digest should be scannable in under 30 seconds. Don't parrot the issue body verbatim — synthesize it.
 
 ## Rules
-- Always target repo: `rogers-obrien-rad/ro-compass-web`.
+- Always detect the repo from the current working directory — never hardcode a repo name.
 - If the issue doesn't exist or the `gh` command fails, report the error clearly.
 - Do not modify, comment on, or take any action on the issue — read only.

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -25,11 +25,30 @@ export function copySkills(packageRoot: string): string[] {
     throw new Error(`Skills directory not found at ${skillsSource}`)
   }
 
+  const sourceSkills = new Set(
+    fs.readdirSync(skillsSource).filter(name =>
+      fs.statSync(path.join(skillsSource, name)).isDirectory()
+    )
+  )
+
+  // Prune installed skills that no longer exist in source
+  if (fs.existsSync(SKILLS_DIR)) {
+    for (const name of fs.readdirSync(SKILLS_DIR)) {
+      const installed = path.join(SKILLS_DIR, name)
+      if (!fs.statSync(installed).isDirectory()) continue
+      const marker = path.join(installed, '.cc-forge')
+      if (fs.existsSync(marker) && !sourceSkills.has(name)) {
+        fs.rmSync(installed, { recursive: true })
+      }
+    }
+  }
+
   const copied: string[] = []
-  for (const name of fs.readdirSync(skillsSource)) {
+  for (const name of sourceSkills) {
     const src = path.join(skillsSource, name)
-    if (!fs.statSync(src).isDirectory()) continue
-    copyDirRecursive(src, path.join(SKILLS_DIR, name))
+    const dest = path.join(SKILLS_DIR, name)
+    copyDirRecursive(src, dest)
+    fs.writeFileSync(path.join(dest, '.cc-forge'), '')
     copied.push(name)
   }
   return copied
@@ -51,16 +70,19 @@ export function copyAgents(packageRoot: string): string[] {
   return copied
 }
 
-export function removeSkills(): string[] {
-  const skillNames = [
-    'branch', 'brainstorm', 'compound', 'create-issue-from-context', 'deepen-plan',
-    'document-review', 'frontend-design', 'git-worktree', 'ideate', 'plan',
-    'review', 'ship', 'sync-github-config', 'work',
-  ]
+export function removeSkills(packageRoot?: string): string[] {
   const removed: string[] = []
-  for (const name of skillNames) {
+  if (!fs.existsSync(SKILLS_DIR)) return removed
+
+  for (const name of fs.readdirSync(SKILLS_DIR)) {
     const dir = path.join(SKILLS_DIR, name)
-    if (fs.existsSync(dir)) {
+    if (!fs.statSync(dir).isDirectory()) continue
+    const marker = path.join(dir, '.cc-forge')
+    // Remove if marker present, or if name matches source skills (legacy installs)
+    const inSource = packageRoot
+      ? fs.existsSync(path.join(packageRoot, 'skills', name))
+      : false
+    if (fs.existsSync(marker) || inSource) {
       fs.rmSync(dir, { recursive: true })
       removed.push(name)
     }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -55,7 +55,7 @@ Skills added:
   /frontend-design           Design-quality frontend code
   /initiative                Author and maintain living initiative docs
   /branch                    Create a branch from an issue number
-  /create-issue-from-context Create GitHub issues from context
+  /issue-from-context        Create GitHub issues from context
   /create-initiative         Publish an initiative to GitHub issues
   /ship                      Commit, push, and create a PR
 

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,10 +1,17 @@
 import { log, outro } from '@clack/prompts'
+import { fileURLToPath } from 'url'
+import path from 'path'
 import { removeSkills, removeAgents } from '../claude.js'
+
+function packageRoot(): string {
+  const distDir = path.dirname(fileURLToPath(import.meta.url))
+  return path.resolve(distDir, '..')
+}
 
 export async function runUninstall(): Promise<void> {
   console.log()
 
-  const removedSkills = removeSkills()
+  const removedSkills = removeSkills(packageRoot())
   if (removedSkills.length > 0) {
     log.success(`Removed skills: ${removedSkills.join(', ')}`)
   }


### PR DESCRIPTION
## Summary

- `/branch` issue number is now optional — when omitted, prefix and description are derived from conversation context, producing `{prefix}/{description}` branches
- `/read-issue` auto-detects the current repo via `gh repo view` instead of hardcoding `rogers-obrien-rad/ro-compass-web`
- Install now prunes stale cc-forge skills using a `.cc-forge` marker, so renamed skills are cleaned up automatically on the next `npm run install`
- `removeSkills` (uninstall) now removes by marker + source presence instead of a hardcoded list
- Fixed install outro to show `/issue-from-context` (the correct post-rename skill name)

### Related Issue

N/A

## Test plan

- [ ] Run `/branch` with no argument in a repo with active conversation context — confirm branch is created as `{prefix}/{description}`
- [ ] Run `/branch <number>` — confirm branch is created as `{prefix}/{number}/{description}` and issue comment is posted
- [ ] Run `/read-issue <number>` in a non-compass repo — confirm it fetches from the current repo
- [ ] Run `npm run build && node dist/cli.mjs install` after renaming a skill — confirm the old skill dir is removed from `~/.claude/skills/`
- [ ] Run `node dist/cli.mjs uninstall` — confirm all cc-forge skills are removed without touching VGC/other-plugin skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)