### PR TITLE
feat(skills): enrich /review output and add /review-walk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/git-worktree` - Manage git worktrees
 - `/frontend-design` - Design-quality frontend code
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
+- `/review-walk` - Guided execution of a `/review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
 
 **Strategic:**
 - `/initiative` - Author or maintain a living high-level initiative doc at `docs/initiatives/`. One altitude up from `/plan` (workstreams, not commit-sized units). Two modes: invoke with no path to author a new initiative; invoke with the path to an existing initiative doc to resume — the skill gathers repo evidence since `last_updated` and writes the update back surgically. Composes with `/create-initiative` (which publishes to GitHub). Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiative <path>` to log progress.

--- a/docs/brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md
+++ b/docs/brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md
@@ -1,0 +1,83 @@
+---
+date: 2026-05-14
+topic: review-grouping-and-walkthrough
+---
+
+# Review Doc Improvements + Guided Walkthrough
+
+## Problem Frame
+
+Today's `/review` workflow produces a P1/P2/P3 issue list, but the user's execution loop has three pain points:
+
+1. **Related issues are scattered across P-levels**, so fixes get made in the wrong order or duplicate effort. Cascades (fixing P1-1 changes the right answer for P2-3) are missed.
+2. **Some issues go over the user's head**, leading to blindly accepting fixes without understanding what was flagged. Learning suffers.
+3. **Some flagged issues aren't real issues**, but there's no signal to skip them quickly.
+
+The user's manual workaround — compact conversation, switch to Sonnet, step through one-by-one — is slow, loses cascade insight, and provides no scaffolding for learning.
+
+The solution splits across two artifacts: a **better review document** (richer fields the reviewer fills in at write-time) and a **new guided walkthrough skill** that consumes that document interactively.
+
+## Requirements
+
+### Review Document Improvements (`/review`)
+
+- **R1.** Each issue gets a `Category:` field. Allowed values: `security`, `correctness`, `performance`, `architecture`, `duplication`, `maintainability`, `testing`, `docs`. (Eight categories; `style` dropped as low-signal.)
+- **R2.** Each issue gets a `Confidence:` field (`high` | `medium` | `low`) and a one-line `Confidence rationale:` set by the reviewing agent at finding-time, based on whether the agent could verify the issue from the code it saw.
+- **R3.** Each issue gets a `Plain English:` field (1–3 sentences) that explains what's wrong in non-jargon terms, ideally with a concrete reference to the user's actual code (e.g., "your code at `auth.rb:42` does X, which means Y").
+- **R4.** The review document gains a top-level `## Groups` section listing clusters that span P-levels. Each group has: a name, the member issue IDs, a `Why grouped:` rationale, a `Suggested order:`, and a `Cascade:` note flagging when fixing one issue affects another. Issues still keep their `P1-1`, `P2-3` IDs and their existing self-contained structure — grouping is additive, not a reorganization.
+- **R5.** Groups are produced during synthesis (Step 1 of the existing Findings Synthesis phase), after dedupe and severity assignment, before the review file is written.
+
+### Guided Walkthrough Skill (`/review-walk`)
+
+- **R6.** Invoked once with a review doc path (or auto-discovers the latest review doc in `docs/reviews/`). Drives the rest of the session from conversation context — no re-invocation needed per issue.
+- **R7.** Walks **group-by-group**, not strictly issue-by-issue. For each group: presents the cluster summary, then teaches the underlying concept in plain English with a concrete example from the user's code, then steps through member issues in the group's `Suggested order:`.
+- **R8.** Per issue, offers four actions: **implement** (apply the fix now), **defer** (mark as out-of-scope to revisit later), **skip** (won't-fix; usually for low-confidence noise), **explain more** (deeper teach-moment before deciding).
+- **R9.** Updates the review doc inline as the user moves: sets each issue's `Status:` to `in-progress`, `done`, `deferred`, or `wont-fix`. The doc is the durable state — resuming a walkthrough means re-reading the doc and continuing from unfinished items.
+- **R10.** Surfaces low-confidence issues with a clear marker ("reviewer flagged this with low confidence — likely safe to skip if it doesn't match your read of the code") so the user can move past noise fast.
+- **R11.** When the user picks **defer**, the skill captures a one-line reason in the doc so future-them knows why it was punted.
+- **R12.** Resumable: invoking `/review-walk <path>` on a partially-walked doc picks up at the first issue whose `Status:` is still `open`.
+
+## Success Criteria
+
+- A typical review-and-walk cycle no longer requires manual compacting or model switching to feel manageable.
+- The user can articulate, in their own words, what each implemented issue was about — the plain-English field and group teach-moment make this the default outcome, not a stretch.
+- Cascade-aware ordering means the user rarely fixes an issue only to find a related one is now moot or differently-shaped.
+- Low-confidence noise is dispatched in seconds, not minutes of investigation.
+
+## Scope Boundaries
+
+- **Not** reorganizing the review doc around groups (issues stay grouped by P-level in their main section; `## Groups` is additive).
+- **Not** building a second-pass "noise filter" agent. Confidence is assigned inline by the reviewing agent at finding-time. We will revisit if low-confidence findings still feel noisy after using this for a few cycles.
+- **Not** changing how `/review` orchestrates agents, runs in parallel/serial, or handles worktrees/PR setup.
+- **Not** adding a `style` category — too low-signal given the agents in use.
+- **Not** building a separate "improvement tracker" — deferred issues live in the review doc with `Status: deferred`, no new file format.
+
+## Key Decisions
+
+- **Two artifacts, not one.** Improving the doc and improving execution are separate concerns. Conflating them would bloat `/review` and still leave execution unstructured.
+- **Confidence is set by the reviewer, not a separate pass.** Same-model self-review is unreliable; inline rationale forces the original agent to be honest about what it could verify.
+- **Group-first walk, not issue-first.** The user's biggest stated pain is missing cross-P-level relationships. Walking by group makes the cascade visible by construction.
+- **Doc is the state.** No separate progress file, no SQLite, no JSON. `Status:` fields in the review doc are the source of truth, which makes resume trivial and keeps the artifact portable.
+- **Eight categories, fixed list.** Open-ended categories drift and lose meaning. Fixed list keeps filtering and future tooling tractable.
+
+## Dependencies / Assumptions
+
+- The existing review template (`docs/reviews/YYYY-MM-DD-NNN-*-review.md`) and stable IDs (`P1-1`, `P2-3`) remain the contract `/review-walk` reads against. If the doc shape changes, the walkthrough must be updated in lockstep.
+- Reviewing agents (`security-sentinel`, `performance-oracle`, etc.) can be instructed via the synthesis step to emit `Category`, `Confidence`, `Confidence rationale`, and `Plain English` fields. We do **not** need to modify each agent definition — the synthesis prompt enforces the fields when writing the doc.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+_None._
+
+### Deferred to Planning
+
+- [Affects R5][Technical] Should grouping be done by the synthesizing model in the existing Step 1, or by a dedicated lightweight "grouper" sub-task? Likely the former for simplicity, but worth a brief check during planning.
+- [Affects R6][Technical] Auto-discovery rule for the latest review doc — newest by filename date+sequence, or by `mtime`? Resolve when implementing.
+- [Affects R9][Technical] Exact Status state machine and how to render `Status:` updates non-destructively in the doc (preserve everything else verbatim). Standard edit-in-place; worth confirming during planning.
+- [Affects R7][Needs research] When teaching the concept for a group, should `/review-walk` always re-read the cited files to ground the example, or trust what the reviewer already wrote? Probably re-read for accuracy; planning should decide the cost/benefit.
+
+## Next Steps
+
+→ `/plan` for structured implementation planning. Recommend planning `/review` updates first (R1–R5), since `/review-walk` (R6–R12) depends on the new fields existing.

--- a/docs/plans/2026-05-14-001-feat-review-grouping-and-walkthrough-plan.md
+++ b/docs/plans/2026-05-14-001-feat-review-grouping-and-walkthrough-plan.md
@@ -1,0 +1,294 @@
+---
+title: "feat: Review doc enrichment + guided walkthrough skill"
+type: feat
+status: completed
+date: 2026-05-14
+origin: docs/brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md
+---
+
+# feat: Review doc enrichment + guided walkthrough skill
+
+## Overview
+
+Two-part change to the code-review workflow in this plugin:
+
+1. **Enrich `/review` output** — every issue gets `Category`, `Confidence` (+ rationale), and `Plain English` fields; the doc gains a top-level `## Groups` section that clusters related issues across P-levels with cascade notes.
+2. **New `/review-walk` skill** — invoked once with a review doc path, walks the user group-by-group with a plain-English teach-moment per group, then through member issues with **implement / defer / skip / explain more** actions, updating `Status:` inline in the doc so progress is durable and resumable.
+
+This replaces the user's manual workflow of compacting the conversation, switching models, and stepping through P1/P2/P3 lists in isolation.
+
+## Problem Frame
+
+See origin: `docs/brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md`. The current review doc lists issues by P-level only, so cross-P cascades are missed, some issues go over the user's head (leading to blind acceptance), and low-confidence noise is indistinguishable from real findings. The user's manual execution loop is slow and unstructured.
+
+## Requirements Trace
+
+Origin doc requirements:
+
+- **R1** — Per-issue `Category:` field (8 fixed values)
+- **R2** — Per-issue `Confidence:` + `Confidence rationale:`
+- **R3** — Per-issue `Plain English:` field
+- **R4** — Top-level `## Groups` section with name, member IDs, why grouped, suggested order, cascade
+- **R5** — Grouping happens during synthesis, before doc is written
+- **R6** — `/review-walk` invoked once, drives session via conversation context; auto-discovers latest review if no path given
+- **R7** — Group-first walk: cluster summary → plain-English teach moment with code example → member issues in suggested order
+- **R8** — Per-issue actions: implement / defer / skip / explain more
+- **R9** — Update `Status:` inline (`in-progress`, `done`, `deferred`, `wont-fix`)
+- **R10** — Low-confidence issues surfaced with clear noise marker
+- **R11** — Defer captures a one-line reason in the doc
+- **R12** — Resume: re-invoke `/review-walk <path>` picks up at first `open` issue
+
+## Scope Boundaries
+
+- Issues stay grouped by P-level in the main `## Issues` section. `## Groups` is additive.
+- No second-pass "noise filter" agent — confidence is inline at finding-time.
+- No changes to `/review`'s orchestration (parallel/serial agents, worktrees, PR setup).
+- No `style` category.
+- No new file format for deferred issues — they live in the review doc with `Status: deferred`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/review/SKILL.md` — the skill being modified. Synthesis happens in Section 5 ("Findings Synthesis, Review Document, and Todo Creation"); the doc template lives there too.
+- `skills/work/SKILL.md` — best existing model for a multi-turn skill that drives a session from a durable doc and resumes from checkbox/status state. `/review-walk` should mirror its "Read Plan and Clarify" → loop pattern.
+- `skills/triage-issue/SKILL.md` and `skills/initiative/SKILL.md` — additional examples of skills that consume a doc, ask one-at-a-time questions, and update the doc inline.
+- `skills/deprecate/SKILL.md` — clean example of skill frontmatter (`user-invocable`, `argument-hint`, `allowed-tools`) and a step-numbered flow.
+- `src/claude.ts` — the install script copies `skills/<name>/` directories to `~/.claude/skills/`. A new skill just needs a new directory under `skills/`; no code changes required.
+
+### Institutional Learnings
+
+- The repo's `CLAUDE.md` is explicit that **changes are not live until `npm run build && node dist/cli.mjs install` runs**. This affects verification steps for both units.
+- The review skill already has a "Protected Artifacts" section discarding findings that target `docs/brainstorms/`, `docs/plans/`, `docs/solutions/`. The walkthrough must respect the same list (never let a user accidentally mark such a finding for execution if one slipped through).
+
+### External References
+
+None — pure repo-internal work, well-patterned by neighboring skills.
+
+## Key Technical Decisions
+
+- **Two skills, two units, one PR-able plan.** Unit 1 lands the doc enrichment; Unit 2 builds the walkthrough. Walkthrough depends on the new fields, so Unit 1 ships first.
+- **Synthesizing model owns grouping, categorization, and plain-English.** Not a separate agent pass. The synthesis step already has every finding in working memory after the parallel reviewers return; doing it there is one prompt, not an orchestration change. (See origin: deferred Q on R5.)
+- **Confidence is set by the originating reviewer**, surfaced through synthesis. Synthesis adds the field structurally if a reviewer didn't supply one (defaulting to `medium` with rationale `"not stated by reviewer"`), so the doc shape is consistent regardless of agent behavior.
+- **Doc-as-state.** `Status:` field per issue is the only progress store. No JSON sidecar, no SQLite. Resume = re-read doc, find first `Status: open`, continue.
+- **Auto-discovery rule:** newest review doc by filename sort (date + zero-padded sequence are both in the name, so lexicographic sort is correct). Avoids `mtime` confusion when files are edited mid-walk. (See origin: deferred Q on R6.)
+- **8 fixed categories**: `security`, `correctness`, `performance`, `architecture`, `duplication`, `maintainability`, `testing`, `docs`. Synthesis instructions enumerate them; reviewers don't need updating.
+- **Group teach-moment re-reads cited files.** Walkthrough should `Read` the files cited in group issues before composing the plain-English explanation, so the example reflects current code rather than the reviewer's snapshot. (See origin: deferred Q on R7 — resolved here in favor of accuracy; cost is small, a handful of Read calls per group.)
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Grouping owner (origin Q on R5):** synthesizing model, in existing Step 1, via additional instructions in the template section of `skills/review/SKILL.md`. Rationale: simpler, no new agent, finding context is already loaded.
+- **Auto-discovery (origin Q on R6):** lexicographic filename sort of `docs/reviews/*.md`, pick last. Filename convention guarantees correctness.
+- **Teach-moment grounding (origin Q on R7):** re-read cited files when composing the group concept explanation. Accuracy outweighs the small token cost.
+- **Status state machine (origin Q on R9):** `open` (initial) → `in-progress` (user picked implement, fix in flight) → `done` | `deferred` | `wont-fix`. The `Status:` line already exists in the template as an HTML-comment-annotated single field; edit-in-place with the `Edit` tool, anchored on the surrounding `### Pn-N:` heading + `**Status:**` line for uniqueness.
+
+### Deferred to Implementation
+
+- Exact prompt wording for synthesis to produce grouping + categories + confidence + plain-English in one pass. Best resolved by iterating against a real review doc during Unit 1.
+- Whether `/review-walk` should offer a "summary mode" at the start (read whole doc, present groups overview before diving in) or jump straight into G1. Probably yes, but the exact UX shape is easier to decide while building.
+- How to handle a review doc that predates Unit 1 (no `Category`/`Confidence`/`Groups` fields). Likely: `/review-walk` falls back to issue-by-issue ordering and skips the teach-moment. Decide at implementation time based on how much fallback code is worth.
+- Whether `defer` should also write a side-quest entry via the existing `/side-quest` skill, or just inline the reason. Probably inline for now — adding side-quest integration is a follow-up.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Review doc shape after Unit 1** (additions shown; existing structure preserved):
+
+```markdown
+## Summary
+| Priority | Count | Label | ... |
+[unchanged]
+
+## Groups                                    ← NEW top-level section
+
+### G1: <name>
+**Issues:** P1-1, P2-3, P3-2
+**Why grouped:** <1-2 sentences>
+**Suggested order:** P1-1 → P2-3 → P3-2
+**Cascade:** Fixing P1-1 likely makes P3-2 moot; if P1-1 is fixed via approach B, revisit P2-3.
+
+---
+
+## Issues
+
+### P1-1: <Short Title>
+**Status:** `open`
+**Category:** security                       ← NEW
+**Confidence:** high                          ← NEW
+**Confidence rationale:** Verified at ...     ← NEW
+**File(s):** path/to/file.rb:42
+**Plain English:** <1-3 sentences in non-jargon terms, grounded in the user's code> ← NEW
+**Problem:** <existing>
+**Fix:** <existing>
+**Effort:** Small | Medium | Large
+```
+
+**`/review-walk` flow** (state lives entirely in the doc + conversation context):
+
+```
+invoke /review-walk [path?]
+  → resolve doc path (arg or auto-discover newest in docs/reviews/)
+  → read doc, parse groups + issues + statuses
+  → if any issue has Status: in-progress, resume there
+  → else find first group whose member issues are not all terminal
+  → for each remaining group:
+      present cluster summary
+      Read cited files to ground the example
+      explain concept in plain English
+      for each member issue in Suggested order (skip terminal statuses):
+        present issue (highlight Confidence: low with noise marker)
+        ask: implement / defer / skip / explain more
+        on implement:    set Status: in-progress → apply fix → set Status: done
+        on defer:        ask one-line reason → set Status: deferred + reason field
+        on skip:         set Status: wont-fix
+        on explain more: deeper teaching, then re-ask
+  → final summary: counts by status, suggest /ship or follow-ups
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Enrich `/review` synthesis output**
+
+**Goal:** Update `skills/review/SKILL.md` so the synthesis step produces a richer review document that includes per-issue `Category`, `Confidence`, `Confidence rationale`, `Plain English` fields, plus a top-level `## Groups` section.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `skills/review/SKILL.md` — extend Section 5 ("Findings Synthesis, Review Document, and Todo Creation"), specifically:
+  - Step 1 "Synthesize All Findings": add grouping, categorization, confidence-normalization, plain-English-composition tasks to the `<synthesis_tasks>` list.
+  - Step 2 "Write Review File": update the markdown template to include the new per-issue fields and the `## Groups` section. Update the issue-writing rules.
+
+**Approach:**
+- Add a fixed category list inline in the SKILL: `security | correctness | performance | architecture | duplication | maintainability | testing | docs`.
+- Define the confidence vocabulary inline: `high` (reviewer verified from code shown), `medium` (pattern match, not verified end-to-end), `low` (heuristic flag, likely needs human judgment).
+- Plain-English rule: 1–3 sentences, must reference at least one concrete code location from the issue's `File(s):`. Forbid jargon-only descriptions.
+- Grouping rule: form a group when ≥2 issues share a root cause, touch the same module/path cluster, or have an explicit fix-order dependency. Single-issue "groups" are not written. Groups can span P-levels.
+- Cascade note is required for every group; if no cascade exists, write `Cascade: independent fixes — no ordering dependency.`
+- Synthesis must default any missing `Confidence` to `medium` with rationale `not stated by reviewer` so the doc shape is uniform.
+
+**Patterns to follow:**
+- The existing Step 2 template structure in `skills/review/SKILL.md` (lines ~275–347) — keep the same heading hierarchy, fence style, and self-contained-issue principle. Add fields, don't restructure.
+- The "Protected Artifacts" block style (boxed callout) for the new category-list and confidence-vocabulary definitions.
+
+**Test scenarios:**
+- Run `/review` against a small real PR or branch; verify the produced doc:
+  - Has a `## Groups` section listing 0+ groups (0 is valid for tiny PRs).
+  - Every issue has all four new fields, none missing.
+  - At least one issue with a verifiable code reference has `Confidence: high`.
+  - Plain English passes the "non-jargon reference" check (mentions a file/line and avoids review-speak like "N+1 anti-pattern" without a follow-up explanation).
+- Edge case: a PR with only one finding — `## Groups` section is present but empty (with a `_None._` placeholder or omitted; pick one and document it in the template).
+- Edge case: two reviewer agents flag the same issue — synthesis dedupes before grouping (existing behavior; verify still works).
+
+**Verification:**
+- Re-installing the plugin (`npm run build && node dist/cli.mjs install`) and re-running `/review` on a sample target produces a doc matching the new template.
+- A spot read of the generated doc shows every issue has all four new fields and any group block carries the required sub-fields.
+
+---
+
+- [x] **Unit 2: New `/review-walk` skill**
+
+**Goal:** Add a new user-invocable skill `skills/review-walk/SKILL.md` that consumes a review doc produced by Unit 1 and drives a guided, group-first walkthrough with inline `Status:` updates and resume support.
+
+**Requirements:** R6, R7, R8, R9, R10, R11, R12
+
+**Dependencies:** Unit 1 (the walkthrough relies on the new fields existing in the doc).
+
+**Files:**
+- Create: `skills/review-walk/SKILL.md` — the new skill.
+- Modify: `CLAUDE.md` — add `/review-walk` to the Skills list under the core workflow grouping (next to `/review`).
+- Modify: `.claude-plugin/plugin.json` (or equivalent skill manifest if present — verify at implementation time; if skills are auto-discovered from `skills/`, no manifest edit is needed).
+
+**Approach:**
+- Frontmatter mirrors `skills/deprecate/SKILL.md`: `name: review-walk`, `description`, `user-invocable: true`, `argument-hint: "[path to review doc]"`, `allowed-tools: Bash, Read, Edit, Agent`.
+- Argument handling: if no path, auto-discover via `ls docs/reviews/*.md | sort | tail -1`. If none found, stop with a helpful message pointing to `/review`.
+- Resume detection: parse the doc, find any issue with `Status: in-progress` first (resumes a mid-flight session); else find the first issue with `Status: open`.
+- Group iteration: for each group with non-terminal members, present the group block, then `Read` each unique file path cited in its member issues' `File(s):` field, then compose the plain-English teach-moment grounded in the actual current code (not just the doc's snapshot).
+- Per-issue prompt presents the four actions via `AskUserQuestion` (single-select). Low-confidence issues get a leading noise marker line: `Reviewer confidence is LOW (<rationale>). Likely safe to skip if it doesn't match your read of the code.`
+- Status transitions use `Edit` on the doc, anchored on the `### Pn-N:` heading + `**Status:**` line for uniqueness. The skill writes:
+  - `Status: in-progress` immediately when implement is chosen, before touching code (so a crash leaves clear state).
+  - `Status: done` after the fix is applied.
+  - `Status: deferred` + new `**Defer reason:**` line for defer.
+  - `Status: wont-fix` for skip.
+- For "explain more", the skill expands on the plain-English teach-moment with a deeper concept walkthrough, then re-asks the same four-action prompt.
+- Orphaned issues (issues not in any group) walk after all groups are processed, issue-by-issue, with no teach-moment header.
+- Fallback for pre-Unit-1 docs (no Groups / Plain English): detect by absence of `## Groups` heading; fall back to strict issue-by-issue order, skip teach-moments, but keep the four-action prompt and status updates.
+
+**Patterns to follow:**
+- `skills/work/SKILL.md` Phase 1 — read-the-plan-first, ask-clarifying-questions-once, then loop. Same posture.
+- `skills/triage-issue/SKILL.md` — single-doc-driven flow with inline updates.
+- `skills/initiative/SKILL.md` — resume-from-doc-state pattern.
+- `skills/deprecate/SKILL.md` — frontmatter and step-numbered structure.
+
+**Execution note:** Iterate the SKILL.md against a real review doc during development — read the skill output, run it mentally on a sample doc, refine the prompt wording. No automated tests; this is prompt engineering.
+
+**Technical design:**
+
+```
+SKILL.md outline:
+  # /review-walk
+  ## Step 1: Resolve doc path
+  ## Step 2: Read doc, parse state, decide entry point
+  ## Step 3: Confirm session start with user (show doc summary)
+  ## Step 4: Group loop
+    4a. Present group block
+    4b. Read cited files
+    4c. Teach concept in plain English with concrete example
+    4d. Issue loop within group
+       - Present issue (with noise marker if low confidence)
+       - Ask four-action question
+       - Execute chosen action (with inline Status update)
+  ## Step 5: Orphan issue loop
+  ## Step 6: Final summary
+  ## Status update protocol (shared subsection)
+  ## Fallback for pre-enrichment docs
+```
+
+**Test scenarios:**
+- Invoke `/review-walk` with no args on a repo that has multiple review docs → picks the lexicographically last one and starts.
+- Invoke `/review-walk` on a doc where all issues are `done` → reports "Walkthrough already complete" and exits.
+- Invoke with one issue marked `in-progress` → resumes there, not at the top.
+- User picks `implement` on a P1 issue → doc shows `Status: in-progress`, fix is applied, doc shows `Status: done`.
+- User picks `defer` → doc shows `Status: deferred` and a new `**Defer reason:** <text>` line.
+- User picks `explain more` → deeper teaching, then re-prompts; doc state unchanged.
+- A P3 issue with `Confidence: low` is presented with the noise marker prefix.
+- Fallback: run the skill against an old review doc (no Groups, no Plain English) → walkthrough proceeds issue-by-issue, no teach-moments, status updates still work.
+
+**Verification:**
+- `npm run build && node dist/cli.mjs install` succeeds and copies the new skill to `~/.claude/skills/review-walk/`.
+- `node dist/cli.mjs doctor` reports the new skill installed.
+- After Claude Code restart, `/review-walk` appears in the available skills list and triggers on invocation.
+- Walking a real review doc end-to-end leaves the doc in a coherent terminal state (every issue `done`, `deferred`, or `wont-fix`).
+
+## System-Wide Impact
+
+- **Interaction graph:** `/review` produces the doc; `/review-walk` consumes and mutates it. No other skill currently writes to `docs/reviews/`. `/ship` reads the working tree, not the review doc, so no conflict.
+- **Error propagation:** If the user aborts mid-walk, the doc reflects last-committed state (any issue mid-implement is left at `Status: in-progress` with no spurious `done`). Resume picks up cleanly.
+- **State lifecycle risks:** The only durable state is the `Status:` line. Edit-in-place anchored on the issue heading is unique enough to avoid collisions (P1-1 vs P2-1 etc.). If the user manually edits the doc between walk turns, the next read picks up their changes — that's a feature.
+- **API surface parity:** None — this is a plugin-local change. The plugin's CLI (`src/claude.ts`) auto-discovers any directory under `skills/`, so the new skill ships with the next install.
+- **Integration coverage:** Manual end-to-end walk of a real review is the integration test. No unit-test infrastructure for skills exists in this repo, by design.
+
+## Risks & Dependencies
+
+- **Risk: synthesis prompt drift.** Adding grouping + categorization + plain-English in one synthesis pass may make that step long. Mitigation: structure the instructions as a checklist in the SKILL.md so the model has explicit cues. If quality drops, split into two passes in a follow-up.
+- **Risk: review docs written before Unit 1 will not match the new shape.** Mitigation: `/review-walk` has an explicit fallback path for pre-enrichment docs. Documented as a deferred-implementation question.
+- **Risk: user installs only one of the two units.** The walkthrough's fallback path keeps it usable against old docs, but the teach-moments only land for new ones. Acceptable; documented.
+- **Dependency: install step.** Per `CLAUDE.md`, neither unit is live until `npm run build && node dist/cli.mjs install` runs. Both units must include that step in their final verification.
+
+## Documentation / Operational Notes
+
+- Update `CLAUDE.md` Skills list to include `/review-walk`.
+- The README (if it lists skills) should be checked at implementation time; update if present.
+- No migration needed for existing `docs/reviews/*.md` files — they continue to work via the walkthrough's fallback path.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md](../brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md)
+- Skill being modified: `skills/review/SKILL.md`
+- Skill patterns to mirror: `skills/work/SKILL.md`, `skills/triage-issue/SKILL.md`, `skills/initiative/SKILL.md`, `skills/deprecate/SKILL.md`
+- Install pipeline: `src/claude.ts`
+- Project conventions: `CLAUDE.md`

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: review-walk
+description: >
+  Walk through a code-review document interactively. Reads a review file produced by
+  /review, presents related issues group-by-group with a plain-English teach moment
+  per group, then steps through each member issue offering implement / defer / skip /
+  explain more. Updates `Status:` inline in the doc so progress is durable and
+  resumable. Triggers on phrases like "walk the review", "step through the review",
+  "review-walk", or passing a path to a docs/reviews/*.md file.
+user-invocable: true
+argument-hint: "[path to docs/reviews/*.md]"
+allowed-tools: Bash, Read, Edit, Write, Agent
+---
+
+# Review Walk
+
+Guide a human through a code-review document one **group of related issues** at a time.
+For each group, teach the underlying concept in plain English before stepping into
+specific fixes. The review document is the source of truth — `Status:` updates live
+in the doc, so walks resume cleanly across sessions.
+
+This skill **consumes** review docs produced by `/review`. It does not run reviewers
+or produce new findings.
+
+## Step 1: Resolve the Doc Path
+
+- If the user passed a path, use it. Verify the file exists with `ls`.
+- If no path was passed, auto-discover the newest review doc:
+
+  ```bash
+  ls docs/reviews/*.md 2>/dev/null | sort | tail -1
+  ```
+
+  The filename convention is `YYYY-MM-DD-NNN-<slug>-review.md`, so a lexicographic
+  sort picks the most recent doc deterministically (no `mtime` ambiguity if the file
+  was edited mid-walk).
+
+- If no review docs exist, STOP and tell the user to run `/review` first.
+- Confirm the resolved path back to the user before continuing:
+  > "Walking review: `docs/reviews/<file>.md`. Proceed?"
+  Use `AskUserQuestion` with Yes / Cancel.
+
+## Step 2: Read the Doc and Detect Shape
+
+Read the full review doc. Determine:
+
+- Whether a top-level `## Groups` section is present.
+- Whether issues carry the enriched fields (`Category:`, `Confidence:`,
+  `Confidence rationale:`, `Plain English:`).
+
+These together determine which mode to run in:
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **Enriched** | `## Groups` present AND issues have enriched fields | Group-first walk with teach moments. |
+| **Fallback** | Either is missing | Issue-by-issue walk in P1 → P2 → P3 order. No teach moments. Status updates still work. |
+
+Fallback exists so the skill is useful against review docs created before the
+enrichment landed. Announce the mode briefly:
+
+> "Enriched review doc detected — running group-first walk with teach moments."
+> or
+> "Older review doc (no Groups section) — falling back to issue-by-issue walk."
+
+## Step 3: Detect Resume Point
+
+Parse every issue's `Status:` line. Decide where to start:
+
+1. If any issue is `Status: in-progress`, **resume there** (a previous walk was
+   interrupted mid-fix). Announce: "Resuming at P1-3 (last left in-progress)."
+2. Else, the entry point is the first non-terminal issue in walk order. Terminal
+   statuses are `done`, `deferred`, `wont-fix`. `open` is non-terminal.
+3. If all issues are terminal, report completion and exit:
+   > "Walkthrough already complete. All N issues are done / deferred / wont-fix."
+   Show a one-line summary of counts by terminal status.
+
+## Step 4: Group Summary (Enriched Mode Only)
+
+Before diving into issues, show the user the lay of the land:
+
+- Total issues, terminal counts so far, groups remaining.
+- A short list of group names with member IDs.
+
+Then ask:
+
+> "Start with G1, jump to a different group, or list orphan issues first?"
+
+Use `AskUserQuestion`. Default: start with the first group whose members are not
+all terminal.
+
+## Step 5: Walk the Groups
+
+For each group with non-terminal members, in order:
+
+### 5a. Present the group block
+
+Show the group's name, member IDs (with current `Status:` next to each), `Why grouped:`,
+`Suggested order:`, and `Cascade:` exactly as written in the doc.
+
+### 5b. Re-read cited files
+
+Collect the unique file paths from the `File(s):` field of each member issue. `Read`
+each one (limit to relevant excerpts when the file is large — the issue's line number
+gives the anchor). This grounds the teach moment in the current code, not in the
+reviewer's snapshot.
+
+### 5c. Teach the underlying concept
+
+Compose a plain-English explanation of what the group is about, framed as a teach
+moment:
+
+- Lead with the concept in non-jargon terms (e.g., "Session validation is happening
+  in two places, and they disagree on what 'valid' means.").
+- Point to one concrete example from the actual code you just read (file + line +
+  short quoted snippet if useful).
+- Keep it to 3–6 sentences. The goal is comprehension, not a lecture.
+
+Then ask:
+
+> "Ready to step through the issues in this group? (implement / defer / skip / explain more)"
+
+Use `AskUserQuestion` to confirm the user wants to enter the issue loop.
+
+### 5d. Issue loop within the group
+
+For each member issue in `Suggested order:`, in order, skipping any already-terminal:
+
+1. **Present the issue.** Show its title, `Category:`, `Status:`, `File(s):`,
+   `Plain English:`, `Problem:`, and `Fix:`. Use the doc's text verbatim.
+
+2. **Noise marker for low confidence.** If `Confidence: low`, prefix the
+   presentation with:
+
+   > **Reviewer confidence is LOW** (rationale: `<Confidence rationale>`). Likely
+   > safe to skip if it doesn't match your read of the code.
+
+   For `Confidence: medium`, show a softer note: "Reviewer confidence: medium —
+   verify before implementing." For `high`, no marker.
+
+3. **Ask the four-action question** via `AskUserQuestion`:
+   - **Implement** — apply the fix now.
+   - **Defer** — out of scope for this pass; capture a one-line reason.
+   - **Skip (won't fix)** — reviewer noise or disagree; close it out.
+   - **Explain more** — deeper teaching, then re-ask.
+
+4. **Execute the chosen action** using the Status Update Protocol (Step 7).
+
+When the group's issues are all terminal, proceed to the next group.
+
+## Step 6: Orphan Issues
+
+After all groups are walked, sweep up any issues that were not members of any group.
+Walk these issue-by-issue in `P1-* → P2-* → P3-*` numeric order. No teach moment;
+present each issue, apply the noise marker rule, ask the four-action question, and
+update status.
+
+## Step 7: Status Update Protocol
+
+The review doc is the durable progress store. Every action mutates the issue's
+`Status:` line (and sometimes appends fields) using the `Edit` tool, anchored on the
+issue's heading + status line so the edit is unambiguous.
+
+### Implement
+
+1. **Before touching code**, set `Status: in-progress` so a crash leaves clear state:
+
+   ```
+   Edit the line:
+     **Status:** `open`
+   under heading `### P<X>-<N>:` → become:
+     **Status:** `in-progress`
+   ```
+
+2. Apply the fix described in `Fix:`. Read the file, make the edit. Follow the doc's
+   instructions; do not invent scope. If the fix is unclear, ask the user before
+   editing code.
+
+3. After the fix is in place, set `Status: done`:
+
+   ```
+     **Status:** `in-progress` → **Status:** `done`
+   ```
+
+4. Briefly confirm to the user what changed and which file(s).
+
+### Defer
+
+1. Ask: "One-line reason for deferring P<X>-<N>?"
+2. Set `Status: deferred` and append a new line directly below the Status line:
+
+   ```
+     **Status:** `deferred`
+     **Defer reason:** <one-line reason from the user>
+   ```
+
+   Anchor the edit on the existing `**Status:** \`open\`` line under the issue's
+   heading.
+
+3. Do not change any other fields. Do not modify code.
+
+### Skip (won't fix)
+
+1. Set `Status: wont-fix`. No reason field required, though the user may volunteer
+   one — if so, append `**Skip reason:** <text>` the same way as defer.
+2. Do not modify code.
+
+### Explain more
+
+1. Provide a deeper plain-English walkthrough of the concept. Aim for the level of
+   detail that would let the user explain it to a colleague. Quote the actual code
+   you re-read in Step 5b.
+2. Re-ask the four-action question. Do not change `Status:`.
+
+### Edit anchoring rule
+
+Status edits must be unique. Anchor each `Edit` call on the **two lines together**:
+the `### P<X>-<N>:` heading line and the `**Status:**` line directly under it (with
+the blank line between them included in `old_string`). This guarantees uniqueness
+even if multiple issues happen to share a Status value.
+
+Example `old_string`:
+
+```
+### P1-3: Missing CSRF check on logout
+
+**Status:** `open`
+```
+
+→ `new_string`:
+
+```
+### P1-3: Missing CSRF check on logout
+
+**Status:** `in-progress`
+```
+
+## Step 8: Final Summary
+
+After all issues are terminal:
+
+- Show counts by terminal status: `done`, `deferred`, `wont-fix`.
+- List deferred items with their reasons (the user may want these as follow-up
+  tickets).
+- Suggest next steps:
+  - If any `done` issues require code changes that aren't yet committed → suggest
+    `/ship`.
+  - If many `deferred` items exist → suggest opening follow-up issues via
+    `/issue-from-context` or `/side-quest`.
+
+## Fallback Mode Details
+
+When running in fallback mode (no `## Groups` section or no enriched fields):
+
+- Skip Step 4 entirely.
+- Skip Step 5a/5b/5c (no teach moment, no group block, no re-read for grounding).
+- Walk issues in strict `P1-* → P2-* → P3-*` numeric order.
+- Apply the four-action question as in enriched mode.
+- For the noise marker: if the issue has no `Confidence:` field, skip the marker
+  entirely (don't fabricate confidence).
+- Status updates work the same way.
+
+## Rules
+
+- Never edit code without setting `Status: in-progress` first.
+- Never fabricate `Confidence:`, `Category:`, or `Plain English:` values when they're
+  missing from the doc. Fallback mode handles their absence gracefully.
+- Never skip the user's chosen action (e.g., don't "implement" when they said
+  "defer").
+- The review doc is the source of truth. If the user manually edits the doc
+  between turns, re-read it before the next action so changes are picked up.
+- Respect the Protected Artifacts rule from `/review`: never apply a fix that would
+  delete or gitignore files under `docs/brainstorms/`, `docs/plans/`, or
+  `docs/solutions/`. If such an issue slipped through, treat it as automatic
+  `wont-fix` and warn the user.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -253,12 +253,50 @@ Remove duplicates, prioritize by severity and impact.
 - [ ] Collect findings from all parallel agents
 - [ ] Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files
 - [ ] Discard any findings that recommend deleting or gitignoring files in `docs/brainstorms/`, `docs/plans/`, or `docs/solutions/` (see Protected Artifacts above)
-- [ ] Categorize by type: security, performance, architecture, quality, etc.
-- [ ] Assign severity levels: 🔴 CRITICAL (P1), 🟡 IMPORTANT (P2), 🔵 NICE-TO-HAVE (P3)
 - [ ] Remove duplicate or overlapping findings
+- [ ] Assign severity levels: 🔴 CRITICAL (P1), 🟡 IMPORTANT (P2), 🔵 NICE-TO-HAVE (P3)
 - [ ] Estimate effort for each finding (Small/Medium/Large)
+- [ ] **Assign a Category** to each finding from the fixed list (see Category vocabulary below)
+- [ ] **Assign Confidence + rationale** to each finding (see Confidence vocabulary below). Default missing confidence to `medium` with rationale `"not stated by reviewer"` so the doc shape is uniform.
+- [ ] **Compose Plain English** for each finding (1–3 sentences, non-jargon, must reference at least one concrete code location from the finding's File(s))
+- [ ] **Form Groups** across P-levels (see Grouping rules below). Single-issue clusters are not written as groups.
 
 </synthesis_tasks>
+
+##### Category vocabulary (fixed list)
+
+Pick exactly one per finding:
+
+- `security` — auth, authz, secrets, injection, sensitive data
+- `correctness` — logic bugs, wrong behavior, broken contracts
+- `performance` — N+1s, hot paths, memory, latency
+- `architecture` — boundary violations, layering, coupling, abstractions
+- `duplication` — copy-paste, near-duplicate logic, missing reuse
+- `maintainability` — naming, readability, complexity, dead code
+- `testing` — missing coverage, weak assertions, flaky tests
+- `docs` — missing or wrong documentation, comments, READMEs
+
+##### Confidence vocabulary
+
+- `high` — reviewer verified the issue from the code shown (e.g., read the function, traced the call, confirmed the bug)
+- `medium` — strong pattern match but not verified end-to-end (e.g., looks like an N+1, but eager-loading upstream wasn't checked)
+- `low` — heuristic flag; likely needs human judgment (e.g., "this name is confusing", "this might be too coupled")
+
+Every finding gets a one-line `Confidence rationale:` stating what was or wasn't verified.
+
+##### Plain English rule
+
+1–3 sentences, no jargon-only descriptions. Must mention at least one concrete file/line from the finding's `File(s)`. If the underlying concept needs a term of art (e.g., "race condition"), follow it with a plain-language gloss tied to the code.
+
+##### Grouping rules
+
+Form a group when **two or more issues** share at least one of:
+
+- A common root cause (same bug expressed in multiple places)
+- The same module, file, or tight path cluster
+- An explicit fix-order dependency (fixing one changes the right answer for another)
+
+Groups can — and should — span P-levels. Do not write single-issue "groups." Every group includes a required `Cascade:` note. If no cascade exists, write `Cascade: independent fixes — no ordering dependency.`
 
 #### Step 2: Write Review File
 
@@ -301,17 +339,45 @@ date: YYYY-MM-DD
 
 ---
 
+## Groups
+
+<!--
+Clusters of related issues that span P-levels. Walk-through tools (e.g. /review-walk)
+read this section to drive a group-first execution flow. If no groups were formed,
+write a single line: `_None — issues are independent._`
+-->
+
+### G1: [Group Name]
+
+**Issues:** P1-1, P2-3, P3-2
+
+**Why grouped:** [1–2 sentences naming the shared root cause, module, or fix-order dependency.]
+
+**Suggested order:** P1-1 → P2-3 → P3-2
+
+**Cascade:** [How fixing one member affects the others. If none, write: `independent fixes — no ordering dependency.`]
+
+---
+
 ## Issues
 
 <!-- Each issue is self-contained — copy a section and paste it into Claude Code to fix. -->
 
 ### P1-1: [Short Title]
 
-**Status:** `open` <!-- open | in-progress | done | wont-fix -->
+**Status:** `open` <!-- open | in-progress | done | deferred | wont-fix -->
+
+**Category:** [one of: security | correctness | performance | architecture | duplication | maintainability | testing | docs]
+
+**Confidence:** [high | medium | low]
+
+**Confidence rationale:** [One line: what was or wasn't verified.]
 
 **File(s):** `path/to/file.ext` (line NNN if applicable)
 
-**Problem:** [1-3 sentences. What is wrong, why it matters, what could go wrong if left unfixed.]
+**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location. E.g., "Your code at `auth.rb:42` trusts the session header without re-validating it, which means a forged header would bypass the check."]
+
+**Problem:** [1–3 sentences. What is wrong, why it matters, what could go wrong if left unfixed.]
 
 **Fix:** [Concrete description of the change needed. Specific enough that Claude Code can act on it without re-investigating. Name the method, pattern, or approach to use. Include the expected behavior after the fix.]
 
@@ -321,9 +387,17 @@ date: YYYY-MM-DD
 
 ### P2-1: [Short Title]
 
-**Status:** `open` <!-- open | in-progress | done | wont-fix -->
+**Status:** `open`
+
+**Category:** [category]
+
+**Confidence:** [high | medium | low]
+
+**Confidence rationale:** [One line.]
 
 **File(s):** `path/to/file.ext`
+
+**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location.]
 
 **Problem:** [1-3 sentences.]
 
@@ -335,9 +409,17 @@ date: YYYY-MM-DD
 
 ### P3-1: [Short Title]
 
-**Status:** `open` <!-- open | in-progress | done | wont-fix -->
+**Status:** `open`
+
+**Category:** [category]
+
+**Confidence:** [high | medium | low]
+
+**Confidence rationale:** [One line.]
 
 **File(s):** `path/to/file.ext`
+
+**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location.]
 
 **Problem:** [1-2 sentences.]
 
@@ -348,11 +430,15 @@ date: YYYY-MM-DD
 
 **Issue writing rules:**
 - Each issue must be fully self-contained — a reader with no other context should be able to paste it into Claude Code and get a correct fix
+- **Category** is required and must come from the fixed list above
+- **Confidence** + **Confidence rationale** are required on every issue (default to `medium` / `"not stated by reviewer"` if the originating agent didn't supply one)
+- **Plain English** is required: 1–3 sentences, non-jargon, with a concrete code reference
 - **File(s)** must include exact paths; add line numbers when the finding is pinpointed to a specific location
 - **Problem** explains what and why, not just what
 - **Fix** describes the concrete change — not just "fix the bug"
 - Keep issues tight: no alternatives, pros/cons tables, or acceptance criteria
 - Number issues sequentially within each tier: P1-1, P1-2, P2-1, P2-2, P3-1, etc.
+- `Status` extends to include `deferred` (for issues a human chose to punt — typically written by `/review-walk`, not by `/review` itself, which always emits `open`)
 
 #### Step 3: Create Todo Files Using todo-create Skill
 


### PR DESCRIPTION
## Summary

Two-part improvement to the code-review workflow:

1. **Enrich `/review` output** — every issue now carries `Category`, `Confidence` (+ rationale), and `Plain English` fields, and the doc gains a top-level `## Groups` section that clusters related issues across P-levels with cascade notes.
2. **New `/review-walk` skill** — consumes the enriched doc and guides the user group-by-group with a plain-English teach moment per group, then through member issues with **implement / defer / skip / explain more**. Updates `Status:` inline so progress is durable and resumable.

Replaces the manual workflow of compacting + model-switching + stepping through P1/P2/P3 lists in isolation.

## Changes

- `skills/review/SKILL.md` — synthesis step extended; doc template gains `## Groups`, `Category`, `Confidence`, `Confidence rationale`, and `Plain English` per issue. Eight-category fixed list documented inline.
- `skills/review-walk/SKILL.md` — new skill with auto-discovery, resume detection, group-first walk, teach moments grounded by re-reading cited files, four-action prompt, anchored inline `Status:` edits, and a fallback mode for pre-enrichment docs.
- `CLAUDE.md` — added `/review-walk` to the core skills list.
- `docs/brainstorms/2026-05-14-review-grouping-and-walkthrough-requirements.md` and `docs/plans/2026-05-14-001-feat-review-grouping-and-walkthrough-plan.md` capture requirements (R1–R12) and the 2-unit plan.

## Related Issue

Closes #24

## Test Plan

- [x] \`npm run build && node dist/cli.mjs install\` succeeds
- [x] \`node dist/cli.mjs doctor\` reports OK
- [x] \`/review-walk\` appears in the available skills list after install
- [ ] Run \`/review\` on a small PR/branch; verify the doc has the new fields and a \`## Groups\` section
- [ ] Run \`/review-walk\` against that doc; verify group-first walk, teach moments, four-action prompt, and inline \`Status:\` updates
- [ ] Re-invoke \`/review-walk\` mid-walk; verify resume picks up at the first non-terminal issue
- [ ] Run \`/review-walk\` against an older review doc; verify fallback mode (no Groups, no teach moments) still works

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a Claude Code plugin change with no runtime/production surface.