### PR TITLE
feat(caveman): add /caveman skill with persistence hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 *.js.map
 .DS_Store
 docs/initiatives/
+docs/plans/
+docs/brainstorms/
 .windsurf/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Personal development workflow plugin with GitHub integration.
 .claude-plugin/   Plugin metadata
 agents/           Specialized subagents (research, review, workflow)
 skills/           Slash commands (SKILL.md files)
+hooks/            Claude Code hook scripts (.cjs, copied to ~/.claude/hooks/)
 ```
 
 ## Agents
@@ -30,6 +31,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/document-review` - Review requirement/plan docs
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
 - `/review-walk` - Guided execution of a `/review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
+- `/caveman` - Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook that re-injects a reminder when active. Off by default. Activate with `/caveman <level>`; deactivate with `/caveman off`, "stop caveman", or "normal mode".
 
 **Strategic:**
 - `/initiative` - Author, maintain, and optionally publish a living high-level initiative doc at `docs/initiatives/`. One altitude up from `/plan` (workstreams, not commit-sized units). Two modes: invoke with no path to author a new initiative; invoke with the path to an existing initiative doc to resume — the skill gathers repo evidence since `last_updated` and writes the update back surgically. After either mode, offers to publish to GitHub as a parent issue with linked sub-tasks. Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiative <path>` to log progress.
@@ -56,9 +58,13 @@ Always run `npm run build && node dist/cli.mjs install` after modifying any skil
 ### Commands
 
 - `npm run build` — compile TypeScript to `dist/`
-- `node dist/cli.mjs install` — copy skills + agents to `~/.claude/`
-- `node dist/cli.mjs uninstall` — remove installed skills + agents
-- `node dist/cli.mjs doctor` — check installation health
+- `node dist/cli.mjs install [--dry-run] [--yes]` — copy skills + agents + hooks; patch `~/.claude/settings.json`
+- `node dist/cli.mjs uninstall [--dry-run]` — manifest-driven removal of everything install created
+- `node dist/cli.mjs doctor` — check installation health (skills, agents, hooks, settings.json wiring, caveman state)
+
+### Hook ownership
+
+`install` writes a manifest at `~/.claude/.cc-forge-manifest.json` recording every entry it adds to `settings.json` (UUID-keyed). `uninstall` consults this manifest to remove exactly those entries — never substring-matches. If you add a new cc-forge hook in the future, register it via the `settings-patcher.ts` module so the manifest stays the canonical ownership record.
 
 ## Agent References in Skills
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,46 @@ This copies all skills and agents to `~/.claude/`. Restart Claude Code after ins
 ### Other commands
 
 ```bash
-node dist/cli.mjs uninstall   # Remove installed skills and agents
-node dist/cli.mjs doctor      # Check installation health
+node dist/cli.mjs install --dry-run   # Print planned changes without writing
+node dist/cli.mjs install --yes       # Skip interactive confirms
+node dist/cli.mjs uninstall           # Remove installed files and settings entries
+node dist/cli.mjs uninstall --dry-run # Print planned removals without touching anything
+node dist/cli.mjs doctor              # Check installation health
 ```
+
+`install` also copies any cc-forge hooks into `~/.claude/hooks/` and (on first install) patches `~/.claude/settings.json` to register them. Ownership of every cc-forge-written settings.json entry is tracked in `~/.claude/.cc-forge-manifest.json` so `uninstall` removes exactly what install added — nothing more.
+
+### Manifest format
+
+`~/.claude/.cc-forge-manifest.json` is a stable, agent-readable record of everything cc-forge owns in your `~/.claude/settings.json`. Schema:
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "uuid": "b68b6ab2-cfea-4916-ab37-4ae87acbe561",
+      "kind": "settings-hook",
+      "event": "UserPromptSubmit",
+      "commandPath": "/Users/you/.claude/hooks/cc-forge-caveman-mode-tracker.cjs",
+      "createdAt": "2026-05-22T17:23:42.875Z"
+    }
+  ]
+}
+```
+
+Agents may read this file to inspect what cc-forge has installed; do not modify it directly. Use `cc-forge doctor --json` for a structured health report that combines manifest state with settings.json wiring and hook state.
+
+### Agent interface
+
+cc-forge exposes machine-friendly surfaces for non-interactive use:
+
+| Action | Command / file |
+|---|---|
+| Install non-interactively | `cc-forge install --yes` |
+| Preview install changes | `cc-forge install --dry-run` |
+| Inspect health as JSON | `cc-forge doctor --json` (exit non-zero on failure) |
+| Toggle caveman mode | Write `lite\|full\|ultra` to `~/.claude/.caveman-active`; `rm` to disable (see `skills/caveman/SKILL.md` for full contract) |
 
 ## After making changes
 
@@ -44,6 +81,7 @@ Changes in `skills/` or `agents/` are not live until install runs.
 | `/document-review` | Review requirement/plan docs |
 | `/deprecate` | Safely plan removal of a named concept |
 | `/test-plan` | Generate a manual test plan from branch diffs |
+| `/caveman` | Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook. Off by default; activate with `/caveman <level>`, deactivate with `/caveman off` or "stop caveman". |
 
 ### Strategic
 
@@ -112,3 +150,7 @@ npm run build      # Compile TypeScript
 npm run typecheck  # Type-check without emitting
 npm run dev        # Watch mode
 ```
+
+## Credits
+
+The `/caveman` skill prompt is adapted from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) under the MIT license. The persistence hook (`hooks/cc-forge-caveman-mode-tracker.cjs`) is an original cc-forge implementation that lifts the symlink-safe flag-file primitives from upstream. The flag file path (`~/.claude/.caveman-active`) is shared between cc-forge and upstream caveman, so installing both will coexist on the same state with cc-forge using a strict `{lite, full, ultra}` whitelist.

--- a/docs/reviews/2026-05-26-001-feat-caveman-skill-hook-review.md
+++ b/docs/reviews/2026-05-26-001-feat-caveman-skill-hook-review.md
@@ -1,0 +1,643 @@
+---
+title: "Review: feat/28/caveman-skill-hook"
+target: branch feat/28/caveman-skill-hook (uncommitted)
+date: 2026-05-26
+---
+
+# Review: feat/28/caveman-skill-hook
+
+Multi-agent review of the uncommitted diff implementing the `/caveman` skill, `UserPromptSubmit` hook, manifest-driven settings.json ownership, and `--dry-run` install/uninstall. Plan at `docs/plans/2026-05-22-001-feat-caveman-skill-and-persistence-hook-plan.md`.
+
+Agents run: kieran-typescript-reviewer, security-sentinel, pattern-recognition-specialist, architecture-strategist, code-simplicity-reviewer, compound-engineering:review:agent-native-reviewer, learnings-researcher (no past learnings exist).
+
+## Summary
+
+| Priority | Count | Label |
+|----------|-------|-------|
+| P1 | 1 | Critical — fix before merge |
+| P2 | 11 | Important — should fix |
+| P3 | 12 | Nice-to-have |
+| **Total** | 24 | |
+
+### P1 Issues
+- [ ] **Stale skill list in install outro** — `/git-worktree`, `/frontend-design`, `/create-initiative` listed but no longer exist in `skills/`
+
+### P2 Issues
+- [ ] **Symlink redirect of `.cc-forge-tmp` temp paths** — manifest + settings.json writes don't use O_NOFOLLOW the way the hook does
+- [ ] **Manifest corruption silently treated as empty entries** — opens duplicate-hook-entry path; violates plan's "distinguish corrupted from missing"
+- [ ] **`commitAddHookEntry` mutates plan after returning** — confusing dual-purpose return shape; `entry: null` for idempotent case forces awkward callers
+- [ ] **Two-store atomicity gap between settings.json and manifest** — if `manifest.addEntry` throws after settings.json write succeeds, ownership invariant breaks
+- [ ] **Uninstall with parse error wedges state** — deletes manifest + hook file even when settings.json couldn't be cleaned, losing UUID record
+- [ ] **Spinner-then-confirm-then-spinner choreography in `wireCavemanHook`** — fights clack's UX; SIGINT mid-confirm leaks spinner state
+- [ ] **Doctor has no `--json` output and never exits non-zero** — agents can't reliably consume doctor output
+- [ ] **settings.json write loses existing mode/ownership** — replaces inode with 0o600 even if user set 0o644 deliberately; no fsync before rename
+- [ ] **`flagFilePath`/`deleteFlagFile` mixed into generic `src/claude.ts`** — caveman-specific helpers leak into the "generic ~/.claude copier" module
+- [ ] **`wireCavemanHook` not abstracted** — second cc-forge hook would duplicate the entire confirm/spinner/dry-run orchestration
+- [ ] **Doctor's hierarchical reporting slides back to flat-list** — failures don't short-circuit; 1 root cause can emit 5 warnings
+
+### P3 Issues
+- [ ] **Stale `entries()` returns mutable internal reference** — leaky abstraction in `manifest.ts`
+- [ ] **`RemovePlan.found` field is cosmetic only** — no consumer materially uses it
+- [ ] **`parseIntent` matches "caveman" anywhere in prompt** — pasted text containing "caveman" + trigger word toggles mode
+- [ ] **`--yes` flag silently accepted but unused by uninstall** — contract drift between CLI and command
+- [ ] **Caveman flag-file contract undocumented for direct writers** — agents can write the flag but the schema lives only in source
+- [ ] **Manifest schema undocumented** — README mentions the file exists but not its shape
+- [ ] **`HOOK_PREFIX` not exported** — literal `cc-forge-caveman-mode-tracker.cjs` duplicated across 3 files
+- [ ] **`JSON.parse` cast to `SettingsShape` without null/array guard** — `null` or `[]` settings.json would NPE downstream
+- [ ] **`packageRoot()` duplicated across install + uninstall** — same 3 lines in two files
+- [ ] **`CLAUDE_DIR` not centralized** — 4 files independently re-derive `path.join(os.homedir(), '.claude', ...)`
+- [ ] **Doctor revalidates flag-file with stricter checks than hook** — duplicates the hook's whitelist/symlink/size logic; redundant once hook is trusted
+- [ ] **Doctor's settings.local.json overlay check is speculative** — no cc-forge code path creates the conflict it warns about
+
+---
+
+## Groups
+
+### G1: Manifest data-integrity cluster
+
+**Issues:** P2-2 (silent corruption), P2-3 (commitAddHookEntry API), P2-4 (two-store atomicity), P2-5 (uninstall parse-error wedge)
+
+**Why grouped:** All four describe the same architectural seam — the manifest as canonical ownership record. P2-2 lets a corrupt manifest masquerade as "empty," P2-3 leaks an internal idempotency-vs-outcome distinction into the API, P2-4 lets settings.json drift ahead of the manifest on partial failure, and P2-5 deletes the manifest even when settings.json couldn't be reconciled. Together they describe a fragile invariant: "the manifest tells the truth about what cc-forge owns."
+
+**Suggested order:** P2-2 → P2-4 → P2-5 → P2-3 (fix detection of corruption first, then two-store atomicity, then uninstall behavior, then API shape last because it's mostly cosmetic now that the underlying semantics are correct).
+
+**Cascade:** Fixing P2-2 (surface manifest parse errors) is a precondition for P2-5 (uninstall behavior on parse error) — without explicit error surfacing, uninstall can't distinguish "manifest empty" from "manifest unreadable." P2-4's compensating rollback is independent and can land in parallel.
+
+---
+
+### G2: Filesystem-write hardening cluster
+
+**Issues:** P2-1 (symlink redirect of temp paths), P2-8 (settings.json mode/ownership/fsync)
+
+**Why grouped:** Both are about the atomic-write primitives in `manifest.ts:39` and `settings-patcher.ts:51`. The hook uses O_NOFOLLOW + lstat checks; the TS-side writes don't. Same fix shape touches both files.
+
+**Suggested order:** P2-1 → P2-8 (fix the symlink hole first; mode preservation can ride on the same write helper).
+
+**Cascade:** Sharing the implementation: extract a `safeAtomicWrite(targetPath, content)` helper into `src/claude.ts` (or a new `src/safe-fs.ts`) that mirrors the hook's `safeWriteFlag` discipline. Both call sites consume it.
+
+---
+
+### G3: Install/uninstall UX + agent-native cluster
+
+**Issues:** P1-1 (stale outro), P2-6 (spinner choreography), P2-7 (no JSON doctor), P3-4 (--yes silently ignored), P3-5 (flag-file contract undoc), P3-6 (manifest schema undoc)
+
+**Why grouped:** All surface the same gap — the install/uninstall/doctor commands work for humans-in-a-terminal but are weak for agents and rough on accuracy. The stale outro is the canonical "humans don't trust the output" symptom; the rest are agent-parity gaps.
+
+**Suggested order:** P1-1 (obvious bug, fix immediately) → P2-7 (doctor --json + exit code; biggest agent-parity win) → P3-4 (--yes contract) → P3-5/P3-6 (docs) → P2-6 (spinner; UX polish, lowest user-visible impact).
+
+**Cascade:** P1-1 + P2-6 are both install.ts touches. P2-7 changes doctor.ts. P3-5 and P3-6 are README/SKILL.md doc adds. No fix dependency between them, but bundle into one commit since they share scope.
+
+---
+
+### G4: Architectural cleanup cluster
+
+**Issues:** P2-9 (claude.ts mixed concerns), P2-10 (wireCavemanHook not abstracted), P2-11 (doctor hierarchy flat)
+
+**Why grouped:** All three describe the same pressure — the implementation works for one hook but second-hook readiness, which was the explicit reason to "abstract now" per the plan, isn't quite there. Module boundary leakage (P2-9), per-hook install orchestration not extracted (P2-10), and doctor's reporting that should be hierarchical per the plan but accumulates booleans instead (P2-11).
+
+**Suggested order:** P2-10 → P2-9 → P2-11. Extracting `wireHook(cfg, opts)` first sets the precedent; moving caveman-state helpers out of claude.ts is a small follow-on; doctor hierarchy is cosmetic but documents the precondition graph.
+
+**Cascade:** P2-10's `wireHook` helper sets the shape; P2-9 then has a clear home for caveman-specific helpers (likely `src/caveman.ts` or fold into settings-patcher). P2-11 is independent.
+
+---
+
+### G5: Simplicity / dead-code cluster
+
+**Issues:** P3-1 (mutable entries), P3-2 (RemovePlan.found), P3-11 (doctor flag revalidation), P3-12 (settings.local overlay speculation), P3-7 (HOOK_PREFIX), P3-9 (packageRoot), P3-10 (CLAUDE_DIR), P3-8 (parse null/array guard)
+
+**Why grouped:** Subtractive edits + duplication cleanup. Each one is small but they share the same problem: "the first-hook implementation is a few exports / branches richer than it needs to be." A single cleanup pass collapses ~50–70 LOC.
+
+**Suggested order:** Bundle into one commit; no ordering dependency.
+
+**Cascade:** independent fixes — no ordering dependency.
+
+---
+
+## Issues
+
+### P1-1: Stale skill list in install outro
+
+**Status:** `done`
+
+**Category:** maintainability
+
+**Confidence:** high
+
+**Confidence rationale:** Three independent reviewers flagged it; verified — commit `9bd5a50` removed these skills but the outro still lists them.
+
+**File(s):** `src/commands/install.ts:100-105`
+
+**Plain English:** The install command's success message tells the user `/git-worktree`, `/frontend-design`, and `/create-initiative` were installed — but those skills were removed from the repo in commit `9bd5a50` and don't ship anymore. New users will type those commands and they won't exist.
+
+**Problem:** The outro lies about what got installed. It will mislead every new user. Worse, the same pattern was in the old install.ts before the rewrite — the rewrite preserved the brittle hardcoded list verbatim instead of sourcing the list from `copied` (the array `copySkills` already returns).
+
+**Fix:** Either (a) delete the three stale lines as a minimum fix, or (b) build the outro list from the `copied` array returned by `copySkills` plus a `description` map keyed by skill name. Option (b) prevents this exact drift from recurring.
+
+**Effort:** Small
+
+---
+
+### P2-1: Symlink redirect of `.cc-forge-tmp` temp paths
+
+**Status:** `done`
+
+**Category:** security
+
+**Confidence:** high
+
+**Confidence rationale:** Verified the code paths — `fs.writeFileSync` on the tmp paths follows symlinks, unlike the hook's `safeWriteFlag` which uses O_NOFOLLOW.
+
+**File(s):** `src/manifest.ts:35-41`, `src/settings-patcher.ts:51-57`
+
+**Plain English:** The hook (`hooks/cc-forge-caveman-mode-tracker.cjs:44-55`) uses `O_NOFOLLOW` and `O_EXCL` when writing the flag file so an attacker can't pre-create a symlink at the target. The manifest and settings.json writers do `fs.writeFileSync(tmp, ...)` first, then rename — but the tmp paths (`${MANIFEST_PATH}.cc-forge-tmp` and `${SETTINGS_PATH}.cc-forge-tmp`) are predictable and `fs.writeFileSync` happily follows symlinks. Pre-planting a symlink at the tmp path redirects the write.
+
+**Problem:** This breaks the symmetry the plan called out. The hook is hardened against this exact pattern because the flag-file path is predictable; the manifest and settings.json paths are equally predictable. cc-forge's single-user threat model accepts "$HOME write = game over" but a cross-user (shared dev box, CI sandbox) attacker with only predictable-path-write capability can use this to escalate before lockdown.
+
+**Fix:** Replace `fs.writeFileSync(tmp, ..., { mode: 0o600 })` with the same `openSync(tmp, O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, 0o600)` + `writeSync` + `closeSync` + `renameSync` pattern used in `safeWriteFlag` (hooks/cc-forge-caveman-mode-tracker.cjs:44-55). Use `process.pid` + `Date.now()` in the tmp name so it isn't a fixed target. Best implemented as a shared `safeAtomicWrite()` helper used by both `manifest.ts` and `settings-patcher.ts`.
+
+**Effort:** Small
+
+---
+
+### P2-2: Manifest corruption silently treated as empty entries
+
+**Status:** `done`
+
+**Category:** correctness
+
+**Confidence:** high
+
+**Confidence rationale:** Read `readManifestRaw` directly — catch-all returns `{ version: 1, entries: [] }` on any error. Verified doctor consumes via `findEntry` without distinguishing the case.
+
+**File(s):** `src/manifest.ts:22-33`, `src/commands/doctor.ts:68`
+
+**Plain English:** If `~/.claude/.cc-forge-manifest.json` is corrupted (truncated, hand-edited badly, unparseable), `readManifestRaw` swallows the error and returns an empty manifest. The next `cc-forge install` then thinks no caveman entry exists, appends a *second* entry to settings.json, and the duplicate fires on every prompt — and the original entry is now orphaned because its UUID is gone.
+
+**Problem:** The plan (line 463) explicitly required distinguishing `corrupted` from `present but missing entry`. The current code conflates them. This is also the inverse of how settings.json is handled — `SettingsParseError` surfaces clearly and refuses to clobber. The manifest, which is supposed to be the canonical ownership record, silently loses data.
+
+**Fix:** Mirror the `SettingsParseError` pattern. Throw on JSON parse failure in `readManifestRaw`; catch at install/uninstall entry points and surface a clear remediation: "manifest at `~/.claude/.cc-forge-manifest.json` is unparseable; verify it doesn't contain entries you need, then remove it and re-run `cc-forge install`." Add a `readManifestSafe(): Manifest | { error: string }` so doctor can report `corrupted` distinctly from `missing entry`.
+
+**Effort:** Small
+
+---
+
+### P2-3: `commitAddHookEntry` mutates plan after returning
+
+**Status:** `done`
+
+**Category:** architecture
+
+**Confidence:** high
+
+**Confidence rationale:** Verified by reading `src/settings-patcher.ts:100-128` — the plan object is mutated post-write (`plan.uuid = entry.uuid`) and the same plan reference is returned to the caller.
+
+**File(s):** `src/settings-patcher.ts:100-128`, `src/commands/install.ts:158,163`
+
+**Plain English:** `commitAddHookEntry` computes a plan (which has `uuid?: undefined` if no entry exists yet), writes the entry, then mutates `plan.uuid = entry.uuid` and returns both the plan and the entry. Callers have to distinguish "newly written" from "already wired" via the awkward expression `entry ? ... : 'Already wired'` (install.ts:158,163). The plan object is now doing double-duty as both intent and outcome.
+
+**Problem:** Plans should describe intent, not carry outcome. The post-commit mutation makes the API surface confusing and the `entry: null` for "already present" forces every caller into a ternary. Future call sites are likely to misuse this.
+
+**Fix:** Drop `uuid?` from `AddPlan` entirely — it's an outcome, not a plan field. Have `commitAddHookEntry` return `{ alreadyPresent: boolean; entry: ManifestEntry }` (always return an entry — look it up via `manifest.findEntry` in the already-present branch). Callers then write `result.alreadyPresent ? 'Already wired' : \`Wired (uuid=${result.entry.uuid.slice(0,8)}…)\``.
+
+**Effort:** Small
+
+---
+
+### P2-4: Two-store atomicity gap between settings.json and manifest
+
+**Status:** `done`
+
+**Category:** correctness
+
+**Confidence:** high
+
+**Confidence rationale:** Verified by reading the sequence in `commitAddHookEntry` and `commitRemoveHookEntry` — there's no compensating action if the second write fails.
+
+**File(s):** `src/settings-patcher.ts:100-129, 152-180`
+
+**Plain English:** `commitAddHookEntry` does `writeSettingsAtomic(settings)` then `manifest.addEntry(...)`. If the manifest write fails (disk full, permission flip, EIO), settings.json now has a hook entry that the manifest doesn't own. Doctor will report a "wiring discrepancy"; uninstall will leave the orphaned settings entry alone because the manifest doesn't know about it. The exact problem the manifest exists to prevent.
+
+**Problem:** The plan called the manifest the "canonical ownership record." But the implementation can land in a state where settings.json knows about an entry the manifest doesn't, with no compensating action. Same shape applies to remove (settings filtered, then manifest entry deletion fails → manifest references a phantom entry).
+
+**Fix:** Wrap the sequence in try/catch. On failure of the second write, revert the first: re-write settings.json without the entry (we still have the pre-mutation copy in scope), then surface the error. For remove, the inverse: re-add to settings.json if manifest cleanup fails.
+
+**Effort:** Medium
+
+---
+
+### P2-5: Uninstall + parse error wedges state
+
+**Status:** `done`
+
+**Category:** correctness
+
+**Confidence:** high
+
+**Confidence rationale:** Verified by reading `src/commands/uninstall.ts:58-104` — the catch logs the error but continues to delete the manifest, leaving the user with no recovery handle.
+
+**File(s):** `src/commands/uninstall.ts:58-104`
+
+**Plain English:** If `cc-forge uninstall` runs while `~/.claude/settings.json` has a parse error, `commitRemoveHookEntry` throws (rightly). The catch at line 65 logs the error but the code continues — it deletes the hook file, deletes the manifest, and deletes the flag file. Now the user has: a settings.json that still references a now-deleted hook, no manifest to identify the UUID, and no record of what cc-forge owned. Their only recovery is hand-editing settings.json.
+
+**Problem:** The manifest exists to make uninstall safe. By deleting it before the settings.json cleanup completes, uninstall destroys its own recovery surface.
+
+**Fix:** On `SettingsParseError` during uninstall, do NOT delete the manifest. Surface: "could not clean settings.json (parse error). The manifest at ~/.claude/.cc-forge-manifest.json is preserved so you can re-run `cc-forge uninstall` after fixing settings.json." The filesystem cleanup (hook file, flag file) can still proceed since those are cc-forge-owned.
+
+**Effort:** Small
+
+---
+
+### P2-6: Spinner-then-confirm-then-spinner in `wireCavemanHook`
+
+**Status:** `done`
+
+**Category:** maintainability
+
+**Confidence:** high
+
+**Confidence rationale:** Traced the control flow — TTY path uses a different spinner lifecycle than non-TTY, both can leak on SIGINT.
+
+**File(s):** `src/commands/install.ts:143-160`
+
+**Plain English:** When the install runs interactively (TTY + not `--yes`), the code starts a spinner labeled "Wiring...", stops it with "Confirming hook installation...", calls `confirm()`, and on accept starts a *new* spinner. If the user hits SIGINT during the confirm, neither spinner is guaranteed clean. The visual flow is also confusing — the first spinner finishes with a "confirming" message that then immediately becomes a prompt.
+
+**Problem:** The pattern fights clack's design. Spinners and confirms should be cleanly separated, not interleaved.
+
+**Fix:** Stop `s` before any interactive prompt. Run `confirm()` outside spinner scope. Start a fresh spinner only after the user confirms. Or: don't start `s` at all until after the confirm.
+
+**Effort:** Small
+
+---
+
+### P2-7: Doctor has no `--json` output and never exits non-zero
+
+**Status:** `done`
+
+**Category:** architecture
+
+**Confidence:** high
+
+**Confidence rationale:** Verified — `doctor.ts:42` returns even when `allGood` is false; no `process.exit(1)`. All output is via `@clack/prompts` styled functions.
+
+**File(s):** `src/commands/doctor.ts:16-46`
+
+**Plain English:** `cc-forge doctor` prints styled human output with ANSI colors and box-drawing characters. An agent that wants to verify "is caveman wired and active?" has to scrape ANSI-decorated strings. The function also returns normally even when checks fail, so `cc-forge doctor && echo ok` always echoes ok.
+
+**Problem:** Doctor is the canonical inspection surface, and it's invisible to agents. cc-forge's design philosophy emphasizes agent-native parity; this is the largest single parity gap.
+
+**Fix:** Add `--json` flag that prints a single JSON object: `{ ok: boolean, checks: [{name, status, detail}], caveman: { hookFile, manifestEntry, settingsWired, mode, localOverlayConflict } }`. Also `process.exit(allGood ? 0 : 1)` so `cc-forge doctor` is usable in `&&` chains.
+
+**Effort:** Small
+
+---
+
+### P2-8: settings.json write loses mode/ownership; no fsync
+
+**Status:** `done`
+
+**Category:** correctness
+
+**Confidence:** high
+
+**Confidence rationale:** Read the write path; `fs.writeFileSync` with hardcoded mode + no fsync.
+
+**File(s):** `src/settings-patcher.ts:51-57`, `src/manifest.ts:35-41`
+
+**Plain English:** When settings.json already exists, the user may have set it to 0644 to let another tool read it. The atomic temp+rename replaces the inode with a 0600 file, silently breaking that. There's also no `fs.fsyncSync(fd)` before rename, so a crash mid-write can yield a zero-byte file and lose the user's settings.
+
+**Problem:** Silent permission tightening + no durability barrier. The mode hardcoded to 0o600 is opinionated — fine for the manifest, less obvious for settings.json which is the user's file.
+
+**Fix:** Before writing, `fs.statSync(SETTINGS_PATH)` to capture existing mode if the file is present; apply that mode to the temp file. Add `fs.fsyncSync(fd)` after write and before rename. Manifest mode can stay 0o600 (cc-forge-owned).
+
+**Effort:** Small
+
+---
+
+### P2-9: `flagFilePath` / `deleteFlagFile` mixed into generic `src/claude.ts`
+
+**Status:** `done`
+
+**Category:** architecture
+
+**Confidence:** medium
+
+**Confidence rationale:** Reasonable judgment call; flagged by two reviewers because the user explicitly considers `src/claude.ts:5-105` clean.
+
+**File(s):** `src/claude.ts:139-153`
+
+**Plain English:** `src/claude.ts` was originally a generic file-copy module ("cc-forge writes/reads things under ~/.claude/"). `flagFilePath()` and `deleteFlagFile()` are caveman-specific runtime state helpers — they don't fit the module's abstraction. The moment a second cc-forge hook lands with its own state file, this becomes awkward.
+
+**Problem:** Module boundary leak. `hookPath()` is generic and fits; `HOOK_PREFIX`/`HOOKS_DIR` are generic and fit. The two flag-file helpers are the odd ones.
+
+**Fix:** Move `flagFilePath` and `deleteFlagFile` into a new tiny `src/caveman.ts` (or inline into `uninstall.ts` since they're used in exactly one place — 5 lines). Keeps `src/claude.ts` as the generic filesystem layer.
+
+**Effort:** Small
+
+---
+
+### P2-10: `wireCavemanHook` not abstracted — second hook would duplicate
+
+**Status:** `wont-fix`
+**Skip reason:** Premature for one-hook ship. Revisit when a second cc-forge hook lands.
+
+**Category:** architecture
+
+**Confidence:** medium
+
+**Confidence rationale:** Verified that the install orchestration (spinner + dry-run + confirm + commit + error message shape) is inline in `install.ts`, not factored out of `SettingsPatcher`.
+
+**File(s):** `src/commands/install.ts:117-172`
+
+**Plain English:** The plan called for `SettingsPatcher` to be "the abstraction now" so a second hook is trivial. The plan/commit split lives in `settings-patcher.ts`, but the install-time orchestration (spinner UX, dry-run text rendering, first-time confirm) is hardcoded inline in `wireCavemanHook`. Adding a second hook means duplicating this whole function.
+
+**Problem:** The abstraction stops at `commitAddHookEntry`. Everything from "user-friendly spinner output" up to "first-time consent prompt" is per-call.
+
+**Fix:** Extract a `wireHook(cfg, opts, { description, dryRunDetail })` helper either in `settings-patcher.ts` or a small `src/wire-hook.ts`. `wireCavemanHook` becomes a one-liner config + call. Second hook is then genuinely a config-only addition.
+
+**Effort:** Medium
+
+---
+
+### P2-11: Doctor's hierarchical reporting slides back to flat-list
+
+**Status:** `done`
+
+**Category:** architecture
+
+**Confidence:** medium
+
+**Confidence rationale:** Verified — `checkCaveman` does sequential `log.warn/success` calls and accumulates `ok`; failures don't short-circuit dependent checks.
+
+**File(s):** `src/commands/doctor.ts:43-145`
+
+**Plain English:** The plan called for hierarchical checks where settings.json wiring gates flag-file meaning. The code does check `wired` before pronouncing "active" — good. But the section runs all 5 checks sequentially regardless of failures, so a missing hook file emits 5 separate warnings about 5 different missing things, when the root cause is "you haven't installed yet."
+
+**Problem:** A user reading 5 warnings has to figure out the dependency graph themselves. The plan asked for actual hierarchy.
+
+**Fix:** Short-circuit on root failures. If the hook file is missing, report only that and return (the rest is implied). If the manifest is missing, report only that. Only descend into wiring/flag checks once preconditions hold.
+
+**Effort:** Small
+
+---
+
+### P3-1: `entries()` returns mutable internal reference
+
+**Status:** `done`
+
+**Category:** maintainability
+
+**Confidence:** medium
+
+**Confidence rationale:** Verified by reading the function; returns `m.entries` directly without copy.
+
+**File(s):** `src/manifest.ts:47-49`
+
+**Plain English:** `entries()` returns the internal array from the parsed JSON object. A caller that mutates it would silently corrupt state on the next read.
+
+**Problem:** Leaky abstraction. The function name suggests a snapshot but returns a live reference.
+
+**Fix:** Return `[...m.entries]` (defensive copy). Trivial change.
+
+**Effort:** Small
+
+---
+
+### P3-2: `RemovePlan.found` field is cosmetic
+
+**Status:** `done`
+
+**Category:** maintainability
+
+**Confidence:** high
+
+**Confidence rationale:** Traced consumers — `found` is only used to print "found in settings.json: true/false" in dry-run output.
+
+**File(s):** `src/settings-patcher.ts:131-151`, `src/commands/uninstall.ts:50-53`
+
+**Plain English:** `planRemoveHookEntry` reads settings.json just to compute a `found` field that's only used as a dry-run cosmetic. `commitRemoveHookEntry` re-reads and re-filters anyway.
+
+**Problem:** Dead computation, ~15 LOC.
+
+**Fix:** Drop `found` from `RemovePlan`. Drop the try/catch at lines 135-142. The filter at 160-165 already handles "not present" as a no-op.
+
+**Effort:** Small
+
+---
+
+### P3-3: `parseIntent` matches "caveman" anywhere in prompt
+
+**Status:** `done`
+
+**Category:** correctness
+
+**Confidence:** high
+
+**Confidence rationale:** Verified the regex patterns — they match anywhere in the full lowercased prompt.
+
+**File(s):** `hooks/cc-forge-caveman-mode-tracker.cjs:99-125`
+
+**Plain English:** A sentence like *"I want to write a blog post about how to enable caveman diets"* matches the activation regex and flips the mode on. Inverse for deactivation phrases. The slash form is unambiguous; natural-language matching on the full prompt is too greedy.
+
+**Problem:** Not a classical exploit, but a false-positive surface. Pasted text, file contents, MCP tool output that gets re-prompted can flip persistent state.
+
+**Fix:** Anchor natural-language patterns to the start of the prompt (`^\s*(please\s+)?(activate|enable|...)\b.*\bcaveman\b`) or only match in the first ~50 chars. The slash form (`/caveman`) keeps full coverage for explicit activation.
+
+**Effort:** Small
+
+---
+
+### P3-4: `--yes` flag silently ignored by uninstall
+
+**Status:** `done`
+
+**Category:** architecture
+
+**Confidence:** high
+
+**Confidence rationale:** Verified — `cli.ts:7-9` parses `--yes`, passes it to `runUninstall`, but `UninstallOptions` doesn't include it.
+
+**File(s):** `src/cli.ts:7-9, 30-33`, `src/commands/uninstall.ts:21-25`
+
+**Plain English:** Help text advertises `--yes` generically. Uninstall accepts the flag but ignores it. Today there are no prompts, so the silent ignore is harmless — but if prompts are added later, behavior diverges from the documented contract.
+
+**Problem:** Contract drift.
+
+**Fix:** Either thread `opts.yes` into `UninstallOptions` for future use, or restrict `--yes` to `install` only and update the help text.
+
+**Effort:** Small
+
+---
+
+### P3-5: Caveman flag-file contract undocumented
+
+**Status:** `done`
+
+**Category:** docs
+
+**Confidence:** high
+
+**Confidence rationale:** Searched README and SKILL.md — only the file path is mentioned, not the schema.
+
+**File(s):** `skills/caveman/SKILL.md:17`, `README.md`
+
+**Plain English:** An agent can toggle caveman by writing `~/.claude/.caveman-active` directly (the hook validates content). But nothing tells the agent this is supported — the contract lives only in hook source. Agents end up parsing slash commands through chat to do something a one-line write would do.
+
+**Problem:** Action parity is technically present but undiscoverable.
+
+**Fix:** Add a "Programmatic control" section to `skills/caveman/SKILL.md` (and an "Agent Interface" block to README): write `lite|full|ultra` to `~/.claude/.caveman-active` to enable; `rm` to disable; content must be trimmed-lowercase, file must not be a symlink, max 64 bytes.
+
+**Effort:** Small
+
+---
+
+### P3-6: Manifest schema undocumented
+
+**Status:** `done`
+
+**Category:** docs
+
+**Confidence:** high
+
+**Confidence rationale:** README mentions the file's purpose; doesn't document its shape.
+
+**File(s):** `README.md:23`, `src/manifest.ts:9-20`
+
+**Plain English:** External tooling (other plugins, CI checks, agents verifying their environment) has no committed contract for the manifest. The `version: 1` field already exists; the schema is stable but undocumented.
+
+**Problem:** Stable schema treated as internal detail.
+
+**Fix:** Add a "Manifest format" subsection to README documenting the entry shape (`uuid, kind, event, commandPath, createdAt`), the version, and a note: "agents may read this file; do not modify."
+
+**Effort:** Small
+
+---
+
+### P3-7: `HOOK_PREFIX` not exported
+
+**Status:** `done`
+
+**Category:** maintainability
+
+**Confidence:** medium
+
+**Confidence rationale:** Verified — literal `cc-forge-caveman-mode-tracker.cjs` appears in install.ts:16 and doctor.ts:13 as `CAVEMAN_HOOK_FILE`.
+
+**File(s):** `src/claude.ts:9`, `src/commands/install.ts:16`, `src/commands/doctor.ts:13`
+
+**Plain English:** `HOOK_PREFIX = 'cc-forge-'` is module-private in claude.ts. But callers know the convention by writing the full filename literal in three places. Renaming the hook means changing three files in lockstep.
+
+**Problem:** Duplicated convention.
+
+**Fix:** Export `HOOK_PREFIX` and a `cavemanHookFilename()` helper. Or just export the full filename as a constant.
+
+**Effort:** Small
+
+---
+
+### P3-8: `JSON.parse` cast to `SettingsShape` without null/array guard
+
+**Status:** `done`
+
+**Category:** correctness
+
+**Confidence:** high
+
+**Confidence rationale:** Verified — the cast trusts `JSON.parse`'s `any` return.
+
+**File(s):** `src/settings-patcher.ts:41-47`, `src/settings-patcher.ts:216-225`
+
+**Plain English:** If a user's settings.json is `null` or `[]`, both are valid JSON but neither is a `SettingsShape` object. Downstream code accessing `settings.hooks` would NPE.
+
+**Problem:** The type cast is a lie.
+
+**Fix:** After parse, validate: `if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) throw new SettingsParseError(new Error('settings.json must be a JSON object'))`. Apply the same guard to `readSettingsLocalSafe`.
+
+**Effort:** Small
+
+---
+
+### P3-9: `packageRoot()` duplicated across install + uninstall
+
+**Status:** `done`
+
+**Category:** duplication
+
+**Confidence:** high
+
+**Confidence rationale:** Identical 3-line function in two files.
+
+**File(s):** `src/commands/install.ts:11-14`, `src/commands/uninstall.ts:16-19`
+
+**Plain English:** The same 3-line function appears in both files. The old codebase had it in install.ts; the rewrite propagated it to uninstall.ts.
+
+**Problem:** Cheap duplication.
+
+**Fix:** Move `packageRoot()` to `src/claude.ts` (or `src/paths.ts`) and import.
+
+**Effort:** Small
+
+---
+
+### P3-10: `CLAUDE_DIR` not centralized
+
+**Status:** `done`
+
+**Category:** duplication
+
+**Confidence:** high
+
+**Confidence rationale:** Verified — 4 files independently call `path.join(os.homedir(), '.claude', ...)`.
+
+**File(s):** `src/claude.ts:5-7`, `src/manifest.ts:6`, `src/settings-patcher.ts:6-7`, `src/commands/doctor.ts:20`
+
+**Plain English:** Four files re-derive the base `~/.claude` path. The pattern was established in `src/claude.ts:5-7`; new modules each ignored it.
+
+**Problem:** If the base ever needs to change (e.g., `CLAUDE_CONFIG_DIR` env var support), four files need to update.
+
+**Fix:** Export `CLAUDE_DIR` constant from `src/claude.ts`; have manifest/settings-patcher/doctor consume it.
+
+**Effort:** Small
+
+---
+
+### P3-11: Doctor revalidates flag-file with stricter checks than hook
+
+**Status:** `done`
+
+**Category:** duplication
+
+**Confidence:** medium
+
+**Confidence rationale:** Verified — doctor.ts:114-134 reimplements the hook's symlink/size/whitelist checks.
+
+**File(s):** `src/commands/doctor.ts:114-134`, `hooks/cc-forge-caveman-mode-tracker.cjs:64-87`
+
+**Plain English:** Doctor re-implements the symlink check, size cap, and content whitelist with slightly different error messages. If the hook is the only writer (and `safeWriteFlag` enforces that), doctor only needs: does the file exist, is the content one of three values.
+
+**Problem:** Belt-and-suspenders.
+
+**Fix:** Collapse to ~3 lines: read file (handle ENOENT), trim+lowercase, check `CAVEMAN_LEVELS.includes`.
+
+**Effort:** Small
+
+---
+
+### P3-12: Doctor's settings.local.json overlay check is speculative
+
+**Status:** `done`
+
+**Category:** maintainability
+
+**Confidence:** medium
+
+**Confidence rationale:** Verified — no cc-forge code path creates the conflict it warns about; the comment at line 104 admits it's informational.
+
+**File(s):** `src/commands/doctor.ts:88-105`
+
+**Plain English:** The overlay check only fires if the user has manually duplicated the cc-forge hook in settings.local.json. cc-forge never writes there itself. This is "just in case" code for a first-hook ship.
+
+**Problem:** Speculative complexity.
+
+**Fix:** Delete lines 88-105 and the `readSettingsLocalSafe`/`settingsLocalPath` exports if no other caller. Re-add when there's evidence the case matters.
+
+**Effort:** Small

--- a/hooks/cc-forge-caveman-mode-tracker.cjs
+++ b/hooks/cc-forge-caveman-mode-tracker.cjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// cc-forge — UserPromptSubmit hook for the /caveman skill.
+//
+// Reads JSON from stdin (Claude Code's UserPromptSubmit payload). Parses the
+// prompt for slash-command and natural-language activation/deactivation of
+// caveman mode. Persists state in a flag file at ~/.claude/.caveman-active.
+// Emits a one-line reinforcement reminder as hookSpecificOutput.additionalContext
+// when the mode is active.
+//
+// Always exits 0 — exit 2 on UserPromptSubmit blocks and erases the prompt,
+// which is catastrophic UX for a mode-tracking hook. Internal errors silent-fail.
+//
+// Adapted from https://github.com/JuliusBrussee/caveman (MIT). cc-forge ships
+// only the lite/full/ultra subset; wenyan levels intentionally omitted.
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const VALID_MODES = ['lite', 'full', 'ultra']
+const MAX_FLAG_BYTES = 64
+const FLAG_PATH = path.join(os.homedir(), '.claude', '.caveman-active')
+
+// --- Symlink-safe flag-file primitives (defense-in-depth) ----------------
+//
+// The flag path is predictable, which is a classic local-attacker target.
+// safeWriteFlag uses O_NOFOLLOW + atomic temp+rename + 0600 perms; readFlag
+// refuses symlinks, caps bytes, and whitelists content. Silent-fail throughout.
+
+function safeWriteFlag(content) {
+  try {
+    const flagDir = path.dirname(FLAG_PATH)
+    fs.mkdirSync(flagDir, { recursive: true })
+
+    // Reject the flag file itself being a symlink (the actual clobber vector).
+    try {
+      if (fs.lstatSync(FLAG_PATH).isSymbolicLink()) return
+    } catch (e) {
+      if (e.code !== 'ENOENT') return
+    }
+
+    const tempPath = path.join(flagDir, `.caveman-active.${process.pid}.${Date.now()}`)
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | O_NOFOLLOW
+    let fd
+    try {
+      fd = fs.openSync(tempPath, flags, 0o600)
+      fs.writeSync(fd, String(content))
+      try { fs.fchmodSync(fd, 0o600) } catch (e) { /* best-effort on Windows */ }
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd)
+    }
+    fs.renameSync(tempPath, FLAG_PATH)
+  } catch (e) {
+    // silent
+  }
+}
+
+function readFlag() {
+  try {
+    let st
+    try {
+      st = fs.lstatSync(FLAG_PATH)
+    } catch (e) {
+      return null
+    }
+    if (st.isSymbolicLink() || !st.isFile()) return null
+    if (st.size > MAX_FLAG_BYTES) return null
+
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0
+    const flags = fs.constants.O_RDONLY | O_NOFOLLOW
+    let fd
+    let out
+    try {
+      fd = fs.openSync(FLAG_PATH, flags)
+      const buf = Buffer.alloc(MAX_FLAG_BYTES)
+      const n = fs.readSync(fd, buf, 0, MAX_FLAG_BYTES, 0)
+      out = buf.slice(0, n).toString('utf8')
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd)
+    }
+
+    const raw = out.trim().toLowerCase()
+    if (!VALID_MODES.includes(raw)) return null
+    return raw
+  } catch (e) {
+    return null
+  }
+}
+
+function unlinkFlag() {
+  try { fs.unlinkSync(FLAG_PATH) } catch (e) { /* silent */ }
+}
+
+// --- Activation / deactivation parsing -----------------------------------
+
+function parseIntent(promptLc) {
+  // Only inspect the first ~80 chars so a pasted block that mentions
+  // "caveman" downstream doesn't accidentally toggle the mode.
+  const head = promptLc.slice(0, 80)
+
+  // Deactivation first — beats activation if both could match (e.g. "stop caveman").
+  if (/^\/caveman\s+(off|stop|disable)\b/.test(head)) return { action: 'off' }
+  if (/^\s*(please\s+)?(stop|disable|deactivate|turn off)\b.*\bcaveman\b/.test(head)) return { action: 'off' }
+  if (/^\s*caveman\b.*\b(stop|disable|deactivate|turn off)\b/.test(head)) return { action: 'off' }
+  if (/^\s*normal mode\b/.test(head)) return { action: 'off' }
+
+  // Slash command activation.
+  const slashMatch = /^\/caveman(?:\s+(\S+))?/.exec(head)
+  if (slashMatch) {
+    const arg = slashMatch[1]
+    if (!arg) return { action: 'on', level: 'full' }
+    if (VALID_MODES.includes(arg)) return { action: 'on', level: arg }
+    return { action: 'noop' } // unknown arg → don't silently overwrite
+  }
+
+  // Natural language activation, anchored to the start of the prompt.
+  if (/^\s*(please\s+)?(activate|enable|turn on|start|talk like|use)\b.*\bcaveman\b/.test(head)) {
+    return { action: 'on', level: 'full' }
+  }
+  if (/^\s*caveman\b.*\b(mode|activate|enable|turn on|start)\b/.test(head)) {
+    return { action: 'on', level: 'full' }
+  }
+
+  return { action: 'noop' }
+}
+
+// --- Reminder text (HARDCODED — see plan Key Technical Decisions) --------
+//
+// Inlined deliberately so a malicious SKILL.md write cannot inject content
+// into the model's context window. Form is a pointer back to the rules, not
+// a restatement, so drift between this string and SKILL.md is intentional
+// and minimal.
+
+function reminderFor(level) {
+  return `CAVEMAN MODE ACTIVE (${level}). Apply skill rules from skills/caveman/SKILL.md. Drop articles/filler/pleasantries; code/commits/security write normal.`
+}
+
+// --- Main ----------------------------------------------------------------
+
+let input = ''
+process.stdin.on('data', (chunk) => { input += chunk })
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input || '{}')
+    const prompt = (data.prompt || '').trim().toLowerCase()
+
+    const intent = parseIntent(prompt)
+    if (intent.action === 'on') {
+      safeWriteFlag(intent.level)
+    } else if (intent.action === 'off') {
+      unlinkFlag()
+    }
+    // 'noop' → flag untouched
+
+    const level = readFlag()
+    if (level) {
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'UserPromptSubmit',
+          additionalContext: reminderFor(level),
+        },
+      }))
+    }
+  } catch (e) {
+    // silent — never exit 2 on UserPromptSubmit
+  }
+  process.exit(0)
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist/",
     "skills/",
-    "agents/"
+    "agents/",
+    "hooks/"
   ],
   "scripts": {
     "build": "tsdown",

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: caveman
+description: 'Ultra-compressed response mode. Cuts token usage by speaking like a smart caveman while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra. Use when the user says "caveman mode", "talk like caveman", "use caveman", "less tokens", "be brief", or invokes /caveman. Auto-triggers when token efficiency is requested.'
+argument-hint: "[lite|full|ultra|off]"
+---
+
+<!-- Skill prompt adapted from https://github.com/JuliusBrussee/caveman (MIT). Persistence hook is an original cc-forge implementation. -->
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+The cc-forge persistence hook re-injects a short reminder of this mode on every `UserPromptSubmit`. Flag file at `~/.claude/.caveman-active`. If the mode appears to drift, check that the hook is wired with `cc-forge doctor`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate prose words (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough. Code symbols, function names, API names, error strings: never abbreviate |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persists across turns via the cc-forge `UserPromptSubmit` hook until changed or removed by `cc-forge uninstall`.
+
+## Programmatic control
+
+Agents may toggle caveman mode by writing the flag file directly — no chat round-trip required.
+
+| Action | Operation |
+|---|---|
+| Enable `lite` / `full` / `ultra` | Write the level (trimmed-lowercase ASCII) to `~/.claude/.caveman-active` |
+| Disable | `rm ~/.claude/.caveman-active` |
+| Inspect current state | `cc-forge doctor --json` and read `caveman.mode` / `caveman.level` |
+
+Validation rules enforced by the hook (`hooks/cc-forge-caveman-mode-tracker.cjs`):
+
+- Content must be one of: `lite`, `full`, `ultra` (anything else is silently ignored)
+- Max file size: 64 bytes
+- File must not be a symlink (`O_NOFOLLOW` on read and write)
+- Writes from the hook itself are atomic temp+rename with mode `0600`
+
+The flag file is shared with [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) if both are installed; cc-forge's strict whitelist means upstream-specific levels (e.g. `wenyan-*`) silently make cc-forge's reminder dormant.

--- a/src/caveman.ts
+++ b/src/caveman.ts
@@ -1,0 +1,16 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// Caveman runtime state — not the bundled hook script. The hook lives in
+// hooks/ and is owned by the generic claude.ts hook copier. The flag file is
+// the mode-state counterpart that the hook reads/writes at runtime.
+
+export const FLAG_FILE = path.join(os.homedir(), '.claude', '.caveman-active')
+
+export function deleteFlagFile(): boolean {
+  if (fs.existsSync(FLAG_FILE)) {
+    try { fs.unlinkSync(FLAG_FILE); return true } catch { return false }
+  }
+  return false
+}

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -4,6 +4,9 @@ import os from 'os'
 
 const SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills')
 const AGENTS_DIR = path.join(os.homedir(), '.claude', 'agents')
+const HOOKS_DIR = path.join(os.homedir(), '.claude', 'hooks')
+
+const HOOK_PREFIX = 'cc-forge-'
 
 function copyDirRecursive(src: string, dest: string): void {
   fs.mkdirSync(dest, { recursive: true })
@@ -101,4 +104,47 @@ export function removeAgents(): string[] {
     }
   }
   return removed
+}
+
+export function copyHooks(packageRoot: string): string[] {
+  const hooksSource = path.join(packageRoot, 'hooks')
+  if (!fs.existsSync(hooksSource)) return []
+
+  fs.mkdirSync(HOOKS_DIR, { recursive: true })
+  const copied: string[] = []
+  for (const name of fs.readdirSync(hooksSource)) {
+    if (!name.startsWith(HOOK_PREFIX)) continue
+    const src = path.join(hooksSource, name)
+    if (!fs.statSync(src).isFile()) continue
+    const dest = path.join(HOOKS_DIR, name)
+    fs.copyFileSync(src, dest)
+    fs.chmodSync(dest, 0o755)
+    copied.push(name)
+  }
+  return copied
+}
+
+export function removeHooks(): string[] {
+  if (!fs.existsSync(HOOKS_DIR)) return []
+  const removed: string[] = []
+  for (const name of fs.readdirSync(HOOKS_DIR)) {
+    if (!name.startsWith(HOOK_PREFIX)) continue
+    const file = path.join(HOOKS_DIR, name)
+    if (!fs.statSync(file).isFile()) continue
+    fs.unlinkSync(file)
+    removed.push(name)
+  }
+  return removed
+}
+
+export function hookPath(name: string): string {
+  return path.join(HOOKS_DIR, name)
+}
+
+export const CLAUDE_DIR = path.join(os.homedir(), '.claude')
+
+export const CAVEMAN_HOOK_FILE = 'cc-forge-caveman-mode-tracker.cjs'
+
+export function packageRoot(distDirOfThisModule: string): string {
+  return path.resolve(distDirOfThisModule, '..')
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,31 +1,40 @@
 #!/usr/bin/env node
 export {}
 
-const command = process.argv[2]
+const args = process.argv.slice(2)
+const command = args[0]
+const hasDryRun = args.includes('--dry-run')
+const hasYes = args.includes('--yes') || args.includes('-y')
+const hasJson = args.includes('--json')
 
 switch (command) {
   case 'install': {
     const { runInstall } = await import('./commands/install.js')
-    await runInstall()
+    await runInstall({ dryRun: hasDryRun, yes: hasYes })
     break
   }
   case 'uninstall': {
     const { runUninstall } = await import('./commands/uninstall.js')
-    await runUninstall()
+    await runUninstall({ dryRun: hasDryRun })
     break
   }
   case 'doctor': {
     const { runDoctor } = await import('./commands/doctor.js')
-    await runDoctor()
+    await runDoctor({ json: hasJson })
     break
   }
   default: {
     console.log(`cc-forge — Development workflows for Claude Code
 
 Usage:
-  npx cc-forge install          Install skills and agents
-  npx cc-forge uninstall        Remove skills and agents
-  npx cc-forge doctor           Check installation health
+  npx cc-forge install [--dry-run] [--yes]   Install skills, agents, and hooks
+  npx cc-forge uninstall [--dry-run]         Remove cc-forge files and settings entries
+  npx cc-forge doctor [--json]               Check installation health (non-zero exit on failure)
+
+Flags:
+  --dry-run        Print planned changes and exit without writing
+  --yes, -y        (install only) Skip the first-time confirm; wire hook automatically
+  --json           (doctor only) Emit a structured JSON report instead of human output
 `)
     process.exit(command ? 1 : 0)
   }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,32 +1,204 @@
 import { intro, log, outro } from '@clack/prompts'
 import fs from 'fs'
 import path from 'path'
-import os from 'os'
+import { CAVEMAN_HOOK_FILE, CLAUDE_DIR, hookPath } from '../claude.js'
+import { FLAG_FILE } from '../caveman.js'
+import * as manifest from '../manifest.js'
+import { isWiredForEntry } from '../settings-patcher.js'
 
-export async function runDoctor(): Promise<void> {
-  console.log()
-  intro('cc-forge doctor')
+const CAVEMAN_LEVELS = ['lite', 'full', 'ultra']
 
-  const home = os.homedir()
-  const checks = [
-    { name: 'Skills (plan)', path: path.join(home, '.claude', 'skills', 'plan', 'SKILL.md') },
-    { name: 'Skills (review)', path: path.join(home, '.claude', 'skills', 'review', 'SKILL.md') },
-    { name: 'Agents (research)', path: path.join(home, '.claude', 'agents', 'research') },
-    { name: 'Agents (review)', path: path.join(home, '.claude', 'agents', 'review') },
-    { name: 'Agents (workflow)', path: path.join(home, '.claude', 'agents', 'workflow') },
+type CheckStatus = 'ok' | 'warn' | 'info'
+
+interface CheckResult {
+  name: string
+  status: CheckStatus
+  detail: string
+}
+
+interface CavemanReport {
+  hookFile: { path: string; present: boolean }
+  manifest: { present: boolean; entryUuid: string | null; orphan: boolean; corrupted: boolean; corruptionDetail: string | null }
+  settingsWired: boolean
+  mode: 'inactive' | 'invalid' | 'active'
+  level: string | null
+}
+
+interface DoctorReport {
+  ok: boolean
+  checks: CheckResult[]
+  caveman: CavemanReport
+}
+
+interface DoctorOptions {
+  json?: boolean
+}
+
+export async function runDoctor(opts: DoctorOptions = {}): Promise<void> {
+  const report = collectReport()
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n')
+    process.exit(report.ok ? 0 : 1)
+  }
+
+  renderHuman(report)
+  process.exit(report.ok ? 0 : 1)
+}
+
+function collectReport(): DoctorReport {
+  const checks: CheckResult[] = []
+
+  const coreChecks = [
+    { name: 'Skills (plan)', path: path.join(CLAUDE_DIR, 'skills', 'plan', 'SKILL.md') },
+    { name: 'Skills (review)', path: path.join(CLAUDE_DIR, 'skills', 'review', 'SKILL.md') },
+    { name: 'Skills (caveman)', path: path.join(CLAUDE_DIR, 'skills', 'caveman', 'SKILL.md') },
+    { name: 'Agents (research)', path: path.join(CLAUDE_DIR, 'agents', 'research') },
+    { name: 'Agents (review)', path: path.join(CLAUDE_DIR, 'agents', 'review') },
+    { name: 'Agents (workflow)', path: path.join(CLAUDE_DIR, 'agents', 'workflow') },
   ]
+  for (const c of coreChecks) {
+    checks.push({
+      name: c.name,
+      status: fs.existsSync(c.path) ? 'ok' : 'warn',
+      detail: fs.existsSync(c.path) ? 'OK' : 'not found',
+    })
+  }
 
-  let allGood = true
-  for (const check of checks) {
-    if (fs.existsSync(check.path)) {
-      log.success(`${check.name}: OK`)
-    } else {
-      log.warn(`${check.name}: not found`)
-      allGood = false
+  const caveman = collectCavemanReport()
+  for (const c of cavemanReportToChecks(caveman)) checks.push(c)
+
+  const ok = checks.every(c => c.status !== 'warn')
+  return { ok, checks, caveman }
+}
+
+function collectCavemanReport(): CavemanReport {
+  const absHookPath = hookPath(CAVEMAN_HOOK_FILE)
+  const hookFilePresent = fs.existsSync(absHookPath)
+
+  const manifestPresent = manifest.manifestExists()
+  const manifestReadResult = manifest.readManifestForReport()
+  const corrupted = 'error' in manifestReadResult
+  const corruptionDetail = corrupted ? manifestReadResult.error.message : null
+
+  const manifestEntry = corrupted
+    ? undefined
+    : manifestReadResult.entries.find(
+        e => e.kind === 'settings-hook' && e.event === 'UserPromptSubmit' && e.commandPath === absHookPath,
+      )
+  const manifestOrphan = manifestPresent && !corrupted && !manifestEntry
+
+  const settingsWired = manifestEntry ? isWiredForEntry(manifestEntry) : false
+
+  // Flag-file: the hook enforces symlink/size/whitelist on write. Trust that
+  // and read simply — if a manual writer broke any of those invariants the
+  // hook would have ignored the file too.
+  let mode: CavemanReport['mode'] = 'inactive'
+  let level: string | null = null
+  if (fs.existsSync(FLAG_FILE)) {
+    try {
+      const content = fs.readFileSync(FLAG_FILE, 'utf8').trim().toLowerCase()
+      if (CAVEMAN_LEVELS.includes(content)) { mode = 'active'; level = content }
+      else mode = 'invalid'
+    } catch {
+      mode = 'invalid'
     }
   }
 
-  // Future: check gh CLI, toggl-cc, etc.
+  return {
+    hookFile: { path: absHookPath, present: hookFilePresent },
+    manifest: {
+      present: manifestPresent,
+      entryUuid: manifestEntry?.uuid || null,
+      orphan: manifestOrphan,
+      corrupted,
+      corruptionDetail,
+    },
+    settingsWired,
+    mode,
+    level,
+  }
+}
 
-  outro(allGood ? 'Everything looks good!' : 'Some checks failed. Run `npx cc-forge install` to fix.')
+function cavemanReportToChecks(c: CavemanReport): CheckResult[] {
+  // Hierarchical: stop at the first root failure.
+  if (!c.hookFile.present) {
+    return [
+      {
+        name: 'Caveman hook',
+        status: 'warn',
+        detail: `hook file not found at ${c.hookFile.path}. Run \`cc-forge install\` to wire.`,
+      },
+    ]
+  }
+
+  if (!c.manifest.present) {
+    return [
+      { name: 'Caveman hook file', status: 'ok', detail: c.hookFile.path },
+      {
+        name: 'Caveman manifest',
+        status: 'warn',
+        detail: 'not found at ~/.claude/.cc-forge-manifest.json. Run `cc-forge install` to wire.',
+      },
+    ]
+  }
+
+  if (c.manifest.corrupted) {
+    return [
+      { name: 'Caveman hook file', status: 'ok', detail: c.hookFile.path },
+      {
+        name: 'Caveman manifest',
+        status: 'warn',
+        detail: `corrupted: ${c.manifest.corruptionDetail}`,
+      },
+    ]
+  }
+
+  if (c.manifest.orphan) {
+    return [
+      { name: 'Caveman hook file', status: 'ok', detail: c.hookFile.path },
+      { name: 'Caveman manifest', status: 'warn', detail: 'present but contains no entry for caveman hook' },
+    ]
+  }
+
+  const out: CheckResult[] = [
+    { name: 'Caveman hook file', status: 'ok', detail: c.hookFile.path },
+    { name: 'Caveman manifest', status: 'ok', detail: `present (uuid=${c.manifest.entryUuid?.slice(0, 8)}…)` },
+    {
+      name: 'Caveman settings.json',
+      status: c.settingsWired ? 'ok' : 'warn',
+      detail: c.settingsWired
+        ? 'wired'
+        : 'not wired (manifest references entry but settings.json does not contain it)',
+    },
+  ]
+
+  if (c.mode === 'invalid') {
+    out.push({ name: 'Caveman mode', status: 'warn', detail: 'flag file is symlinked, oversized, or unrecognized — delete manually' })
+  } else if (c.mode === 'inactive') {
+    out.push({ name: 'Caveman mode', status: 'ok', detail: 'inactive' })
+  } else if (c.mode === 'active') {
+    if (!c.settingsWired) {
+      out.push({
+        name: 'Caveman mode',
+        status: 'warn',
+        detail: `active (${c.level}) BUT hook not wired — mode will not take effect. Run \`cc-forge install\` to fix.`,
+      })
+    } else {
+      out.push({ name: 'Caveman mode', status: 'ok', detail: `active (${c.level})` })
+    }
+  }
+
+  return out
+}
+
+function renderHuman(report: DoctorReport): void {
+  console.log()
+  intro('cc-forge doctor')
+  for (const c of report.checks) {
+    if (c.status === 'ok') log.success(`${c.name}: ${c.detail}`)
+    else if (c.status === 'warn') log.warn(`${c.name}: ${c.detail}`)
+    else log.info(`${c.name}: ${c.detail}`)
+  }
+  outro(report.ok ? 'Everything looks good!' : 'Some checks failed. Run `npx cc-forge install` to fix.')
 }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,16 +1,51 @@
-import { intro, outro, spinner, log } from '@clack/prompts'
+import { intro, outro, spinner, log, confirm, isCancel } from '@clack/prompts'
 import { fileURLToPath } from 'url'
 import path from 'path'
-import { copySkills, copyAgents } from '../claude.js'
+import { CAVEMAN_HOOK_FILE, copySkills, copyAgents, copyHooks, hookPath, packageRoot } from '../claude.js'
+import { ManifestParseError } from '../manifest.js'
+import {
+  planAddHookEntry,
+  commitAddHookEntry,
+  SettingsParseError,
+} from '../settings-patcher.js'
 
-function packageRoot(): string {
-  const distDir = path.dirname(fileURLToPath(import.meta.url))
-  return path.resolve(distDir, '..')
+const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+
+// One-line description per skill, keyed by skill directory name. Used to render
+// the install outro. Missing keys fall back to "(no description)" so adding a
+// new skill that lacks an entry here doesn't break the outro.
+const SKILL_DESCRIPTIONS: Record<string, string> = {
+  brainstorm: 'Explore requirements and approaches',
+  plan: 'Create implementation plans',
+  work: 'Execute work plans',
+  review: 'Multi-agent code review',
+  'review-walk': 'Walk through a review doc interactively',
+  compound: 'Document learnings',
+  ideate: 'Generate improvement ideas',
+  'deepen-plan': 'Stress-test plans with targeted research',
+  'document-review': 'Review requirement/plan docs',
+  deprecate: 'Plan removal of a named concept',
+  'test-plan': 'Generate a manual test plan from branch diffs',
+  initiative: 'Author and maintain living initiative docs',
+  branch: 'Create a branch from an issue number',
+  'issue-from-context': 'Create GitHub issues from context',
+  'read-issue': 'Fetch and digest a GitHub issue',
+  'triage-issue': 'Investigate whether an issue still exists',
+  ship: 'Commit, push, and create a PR',
+  'commit-all': 'Stage and commit all changes per-file',
+  'side-quest': 'Track out-of-scope tasks discovered during execution',
+  'stand-up': 'Summarize the past 28h of work',
+  caveman: 'Ultra-terse response mode (persists via UserPromptSubmit hook)',
 }
 
-export async function runInstall(): Promise<void> {
+interface InstallOptions {
+  dryRun?: boolean
+  yes?: boolean
+}
+
+export async function runInstall(opts: InstallOptions = {}): Promise<void> {
   console.log()
-  intro('cc-forge — Development workflows for Claude Code')
+  intro(opts.dryRun ? 'cc-forge — Dry run (no changes will be made)' : 'cc-forge — Development workflows for Claude Code')
 
   const [major] = process.versions.node.split('.').map(Number)
   if (major < 18) {
@@ -18,48 +53,154 @@ export async function runInstall(): Promise<void> {
     process.exit(1)
   }
 
-  // Copy skills
+  // Skills
+  let installedSkills: string[] = []
   const s1 = spinner()
-  s1.start('Copying skills to ~/.claude/skills/...')
+  s1.start(opts.dryRun ? 'Planning skills copy...' : 'Copying skills to ~/.claude/skills/...')
   try {
-    const copied = copySkills(packageRoot())
-    s1.stop(`Copied ${copied.length} skill(s): ${copied.join(', ')}`)
+    if (opts.dryRun) {
+      s1.stop(`Would copy skills from ${packageRoot(moduleDir)}/skills/ to ~/.claude/skills/`)
+    } else {
+      installedSkills = copySkills(packageRoot(moduleDir))
+      s1.stop(`Copied ${installedSkills.length} skill(s): ${installedSkills.join(', ')}`)
+    }
   } catch (err) {
     s1.stop('Failed to copy skills')
     log.error(String(err))
   }
 
-  // Copy agents
+  // Agents
+  let installedAgents: string[] = []
   const s2 = spinner()
-  s2.start('Copying agents to ~/.claude/agents/...')
+  s2.start(opts.dryRun ? 'Planning agents copy...' : 'Copying agents to ~/.claude/agents/...')
   try {
-    const copied = copyAgents(packageRoot())
-    s2.stop(`Copied agent categories: ${copied.join(', ')}`)
+    if (opts.dryRun) {
+      s2.stop(`Would copy agents from ${packageRoot(moduleDir)}/agents/ to ~/.claude/agents/`)
+    } else {
+      installedAgents = copyAgents(packageRoot(moduleDir))
+      s2.stop(`Copied agent categories: ${installedAgents.join(', ')}`)
+    }
   } catch (err) {
     s2.stop('Failed to copy agents')
     log.error(String(err))
   }
 
-  outro(`cc-forge installed!
+  // Hooks
+  let installedHooks: string[] = []
+  const s3 = spinner()
+  s3.start(opts.dryRun ? 'Planning hooks copy...' : 'Copying hooks to ~/.claude/hooks/...')
+  try {
+    if (opts.dryRun) {
+      s3.stop(`Would copy hook(s) from ${packageRoot(moduleDir)}/hooks/ to ~/.claude/hooks/`)
+    } else {
+      installedHooks = copyHooks(packageRoot(moduleDir))
+      if (installedHooks.length === 0) {
+        s3.stop('No hooks to copy')
+      } else {
+        s3.stop(`Copied hook(s): ${installedHooks.join(', ')}`)
+      }
+    }
+  } catch (err) {
+    s3.stop('Failed to copy hooks')
+    log.error(String(err))
+  }
 
-Skills added:
-  /brainstorm                Explore requirements and approaches
-  /plan                      Create implementation plans
-  /work                      Execute work plans
-  /review                    Multi-agent code review
-  /compound                  Document learnings
-  /ideate                    Generate improvement ideas
-  /deepen-plan               Enhance plans with research
-  /document-review           Review requirement/plan docs
-  /git-worktree              Manage git worktrees
-  /frontend-design           Design-quality frontend code
-  /initiative                Author and maintain living initiative docs
-  /branch                    Create a branch from an issue number
-  /issue-from-context        Create GitHub issues from context
-  /create-initiative         Publish an initiative to GitHub issues
-  /ship                      Commit, push, and create a PR
+  // Settings.json patch for caveman hook
+  await wireCavemanHook(opts)
 
-Agent categories: research, review, workflow
+  outro(buildOutro({ opts, installedSkills, installedAgents, installedHooks }))
+}
 
-Restart Claude Code for changes to take effect.`)
+interface OutroInput {
+  opts: InstallOptions
+  installedSkills: string[]
+  installedAgents: string[]
+  installedHooks: string[]
+}
+
+function buildOutro({ opts, installedSkills, installedAgents, installedHooks }: OutroInput): string {
+  const header = opts.dryRun
+    ? 'cc-forge install --dry-run complete\n(Dry run — no files were created or modified.)\n'
+    : 'cc-forge installed!\n'
+
+  const skillsBlock = installedSkills.length === 0
+    ? '\nSkills added: (none — install step skipped or failed)'
+    : '\nSkills added:\n' +
+      installedSkills
+        .sort()
+        .map(name => `  /${name.padEnd(22)} ${SKILL_DESCRIPTIONS[name] || '(no description)'}`)
+        .join('\n')
+
+  const agentsBlock = installedAgents.length === 0
+    ? '\n\nAgent categories: (none)'
+    : `\n\nAgent categories: ${installedAgents.join(', ')}`
+
+  const hooksBlock = installedHooks.length === 0
+    ? ''
+    : '\n\nHooks installed:\n' + installedHooks.map(name => `  ${name}  (UserPromptSubmit; off by default)`).join('\n')
+
+  const footer = '\n\nRestart Claude Code for changes to take effect.'
+
+  return header + skillsBlock + agentsBlock + hooksBlock + footer
+}
+
+async function wireCavemanHook(opts: InstallOptions): Promise<void> {
+  const absHookPath = hookPath(CAVEMAN_HOOK_FILE)
+  const cfg = { event: 'UserPromptSubmit', command: absHookPath, timeout: 10 }
+
+  // Step 1: plan (no spinner — pure read of manifest, instantaneous)
+  let plan
+  try {
+    plan = planAddHookEntry(cfg)
+  } catch (err) {
+    log.error('Failed to plan UserPromptSubmit hook wiring')
+    if (err instanceof SettingsParseError || err instanceof ManifestParseError) log.error(err.message)
+    else log.error(String(err))
+    return
+  }
+
+  if (plan.alreadyPresent) {
+    log.success('UserPromptSubmit hook already wired (skipped)')
+    return
+  }
+
+  if (opts.dryRun) {
+    log.info(
+      `Would add UserPromptSubmit hook to ~/.claude/settings.json:\n` +
+        `    matcher: ""\n` +
+        `    hooks:[{ type: "command", command: "${absHookPath}", timeout: 10 }]\n` +
+        `    manifest entry: kind=settings-hook, event=UserPromptSubmit`,
+    )
+    return
+  }
+
+  // Step 2: confirm (no spinner around interactive prompt)
+  if (!opts.yes && process.stdin.isTTY) {
+    const proceed = await confirm({
+      message:
+        'cc-forge will add a UserPromptSubmit hook to ~/.claude/settings.json. This makes /caveman persistence possible. Continue?',
+    })
+    if (isCancel(proceed) || proceed !== true) {
+      log.warn(
+        'Skipped settings.json patch. /caveman skill will still work, but persistence requires the hook. Re-run `cc-forge install` to wire it.',
+      )
+      return
+    }
+  }
+
+  // Step 3: commit (single spinner for the actual disk write)
+  const s = spinner()
+  s.start('Wiring UserPromptSubmit hook in settings.json...')
+  try {
+    const { alreadyPresent, entry } = commitAddHookEntry(cfg)
+    s.stop(
+      alreadyPresent
+        ? `UserPromptSubmit hook already wired (uuid=${entry.uuid.slice(0, 8)}…)`
+        : `Wired UserPromptSubmit hook (uuid=${entry.uuid.slice(0, 8)}…)`,
+    )
+  } catch (err) {
+    s.stop('Failed to wire UserPromptSubmit hook')
+    if (err instanceof SettingsParseError || err instanceof ManifestParseError) log.error(err.message)
+    else log.error(String(err))
+  }
 }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,25 +1,141 @@
-import { log, outro } from '@clack/prompts'
+import { intro, log, outro, spinner } from '@clack/prompts'
 import { fileURLToPath } from 'url'
 import path from 'path'
-import { removeSkills, removeAgents } from '../claude.js'
+import {
+  removeSkills,
+  removeAgents,
+  removeHooks,
+  packageRoot,
+} from '../claude.js'
+import { deleteFlagFile } from '../caveman.js'
+import * as manifest from '../manifest.js'
+import { ManifestParseError } from '../manifest.js'
+import {
+  commitRemoveHookEntry,
+  planRemoveHookEntry,
+  SettingsParseError,
+} from '../settings-patcher.js'
 
-function packageRoot(): string {
-  const distDir = path.dirname(fileURLToPath(import.meta.url))
-  return path.resolve(distDir, '..')
+const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+
+interface UninstallOptions {
+  dryRun?: boolean
 }
 
-export async function runUninstall(): Promise<void> {
+export async function runUninstall(opts: UninstallOptions = {}): Promise<void> {
   console.log()
+  intro(opts.dryRun ? 'cc-forge uninstall — Dry run (no changes will be made)' : 'cc-forge uninstall')
 
-  const removedSkills = removeSkills(packageRoot())
-  if (removedSkills.length > 0) {
-    log.success(`Removed skills: ${removedSkills.join(', ')}`)
+  // Track whether every settings.json cleanup succeeded; if any failed, we
+  // preserve the manifest so a re-run can finish the job.
+  let settingsCleanupComplete = true
+
+  // Read manifest safely — corruption shouldn't crash uninstall before we get
+  // a chance to clean up filesystem-only state.
+  const manifestRead = manifest.readManifestForReport()
+  if ('error' in manifestRead) {
+    log.warn(`Manifest is corrupted; skipping settings.json cleanup. ${manifestRead.error.message}`)
+    settingsCleanupComplete = false
+  } else if (manifestRead.entries.length === 0) {
+    log.info('No manifest entries to remove from settings.json')
+  } else {
+    for (const entry of manifestRead.entries) {
+      const s = spinner()
+      s.start(
+        opts.dryRun
+          ? `Planning removal of ${entry.kind} entry (${entry.event}, uuid=${entry.uuid.slice(0, 8)}…)...`
+          : `Removing ${entry.kind} entry (${entry.event}, uuid=${entry.uuid.slice(0, 8)}…)...`,
+      )
+
+      if (opts.dryRun) {
+        try {
+          const plan = planRemoveHookEntry(entry.uuid)
+          if (!plan) {
+            s.stop(`Manifest entry not found (already cleaned?)`)
+          } else {
+            s.stop(
+              `Would remove from ~/.claude/settings.json:\n` +
+                `    event: ${plan.event}\n` +
+                `    command: ${plan.command}`,
+            )
+          }
+        } catch (err) {
+          s.stop(`Failed to plan removal of ${entry.event} entry`)
+          if (err instanceof SettingsParseError) log.error(err.message)
+          else log.error(String(err))
+          settingsCleanupComplete = false
+        }
+        continue
+      }
+
+      try {
+        const result = commitRemoveHookEntry(entry.uuid)
+        if (!result) {
+          s.stop('Manifest entry not found')
+        } else {
+          s.stop(`Removed ${result.event} entry`)
+        }
+      } catch (err) {
+        s.stop(`Failed to remove ${entry.event} entry`)
+        if (err instanceof SettingsParseError || err instanceof ManifestParseError) {
+          log.error(err.message)
+        } else {
+          log.error(String(err))
+        }
+        settingsCleanupComplete = false
+      }
+    }
   }
 
-  const removedAgents = removeAgents()
-  if (removedAgents.length > 0) {
-    log.success(`Removed agent categories: ${removedAgents.join(', ')}`)
+  // Filesystem cleanup — runs even if settings.json cleanup failed, because
+  // these files are cc-forge-owned and re-installable.
+  if (opts.dryRun) {
+    log.info(`Would remove cc-forge-owned files from ~/.claude/skills/, ~/.claude/agents/, ~/.claude/hooks/`)
+    log.info(`Would delete ~/.claude/.caveman-active if present`)
+    if (settingsCleanupComplete) {
+      log.info(`Would delete ~/.claude/.cc-forge-manifest.json`)
+    } else {
+      log.warn(`Would PRESERVE ~/.claude/.cc-forge-manifest.json (settings.json cleanup did not complete)`)
+    }
+  } else {
+    const removedSkills = removeSkills(packageRoot(moduleDir))
+    if (removedSkills.length > 0) {
+      log.success(`Removed skills: ${removedSkills.join(', ')}`)
+    }
+
+    const removedAgents = removeAgents()
+    if (removedAgents.length > 0) {
+      log.success(`Removed agent categories: ${removedAgents.join(', ')}`)
+    }
+
+    const removedHooks = removeHooks()
+    if (removedHooks.length > 0) {
+      log.success(`Removed hooks: ${removedHooks.join(', ')}`)
+    }
+
+    if (deleteFlagFile()) {
+      log.success('Deleted ~/.claude/.caveman-active')
+    }
+
+    if (settingsCleanupComplete) {
+      if (manifest.manifestExists()) {
+        manifest.deleteManifest()
+        log.success('Deleted ~/.claude/.cc-forge-manifest.json')
+      }
+    } else if (manifest.manifestExists()) {
+      log.warn(
+        'Preserved ~/.claude/.cc-forge-manifest.json because settings.json cleanup did not complete. Fix the parse error in settings.json, then re-run `cc-forge uninstall`.',
+      )
+    }
   }
 
-  outro('cc-forge uninstalled. Restart Claude Code for changes to take effect.')
+  const outroMessage = settingsCleanupComplete
+    ? opts.dryRun
+      ? 'cc-forge uninstall --dry-run complete. (No changes made.)'
+      : 'cc-forge uninstalled. Restart Claude Code for changes to take effect.'
+    : 'cc-forge uninstall partial. Some settings.json entries could not be cleaned; manifest preserved for retry.'
+
+  outro(outroMessage)
+
+  if (!settingsCleanupComplete) process.exit(1)
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,0 +1,120 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+import { safeAtomicWrite } from './safe-fs.js'
+
+const MANIFEST_PATH = path.join(os.homedir(), '.claude', '.cc-forge-manifest.json')
+const MANIFEST_VERSION = 1
+
+export interface ManifestEntry {
+  uuid: string
+  kind: 'settings-hook'
+  event: string
+  commandPath: string
+  createdAt: string
+}
+
+interface Manifest {
+  version: number
+  entries: ManifestEntry[]
+}
+
+export class ManifestParseError extends Error {
+  constructor(public readonly underlying: unknown) {
+    super(
+      `~/.claude/.cc-forge-manifest.json is not valid JSON. cc-forge uses this file to track what it owns in settings.json — losing it means losing your uninstall handle. Inspect the file; if you can't recover it and don't have cc-forge entries to preserve, remove it and re-run \`cc-forge install\`. Underlying: ${String(underlying)}`,
+    )
+    this.name = 'ManifestParseError'
+  }
+}
+
+function readManifestRaw(): Manifest {
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    return { version: MANIFEST_VERSION, entries: [] }
+  }
+  let raw: string
+  try {
+    raw = fs.readFileSync(MANIFEST_PATH, 'utf8')
+  } catch (e) {
+    throw new ManifestParseError(e)
+  }
+  if (raw.trim().length === 0) {
+    return { version: MANIFEST_VERSION, entries: [] }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (e) {
+    throw new ManifestParseError(e)
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    Array.isArray(parsed) ||
+    !Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    throw new ManifestParseError(new Error('manifest must be a JSON object with an `entries` array'))
+  }
+  const obj = parsed as { version?: number; entries: ManifestEntry[] }
+  return { version: obj.version || MANIFEST_VERSION, entries: obj.entries }
+}
+
+// Best-effort variant for callers that should never throw on a corrupt manifest
+// (e.g., the doctor command, which wants to *report* the corruption itself).
+function readManifestSafe(): Manifest | { error: ManifestParseError } {
+  try {
+    return readManifestRaw()
+  } catch (e) {
+    if (e instanceof ManifestParseError) return { error: e }
+    return { error: new ManifestParseError(e) }
+  }
+}
+
+function writeManifestAtomic(m: Manifest): void {
+  safeAtomicWrite(MANIFEST_PATH, JSON.stringify(m, null, 2), { mode: 0o600 })
+}
+
+// Throws ManifestParseError on corruption — call sites that need to act on the
+// manifest (install/uninstall) propagate; the doctor command uses
+// `readManifestForReport` instead.
+export function entries(): ManifestEntry[] {
+  return [...readManifestRaw().entries]
+}
+
+export function findEntry(predicate: (e: ManifestEntry) => boolean): ManifestEntry | undefined {
+  return readManifestRaw().entries.find(predicate)
+}
+
+export function readManifestForReport(): Manifest | { error: ManifestParseError } {
+  return readManifestSafe()
+}
+
+export function addEntry(partial: Omit<ManifestEntry, 'uuid' | 'createdAt'>): ManifestEntry {
+  const m = readManifestRaw()
+  const entry: ManifestEntry = {
+    ...partial,
+    uuid: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+  }
+  m.entries.push(entry)
+  writeManifestAtomic(m)
+  return entry
+}
+
+export function removeEntry(uuid: string): boolean {
+  const m = readManifestRaw()
+  const before = m.entries.length
+  m.entries = m.entries.filter(e => e.uuid !== uuid)
+  if (m.entries.length === before) return false
+  writeManifestAtomic(m)
+  return true
+}
+
+export function deleteManifest(): void {
+  try { fs.unlinkSync(MANIFEST_PATH) } catch (e) { /* silent */ }
+}
+
+export function manifestExists(): boolean {
+  return fs.existsSync(MANIFEST_PATH)
+}

--- a/src/safe-fs.ts
+++ b/src/safe-fs.ts
@@ -1,0 +1,58 @@
+import fs from 'fs'
+import path from 'path'
+
+// Atomic write with symlink-safe temp path, fsync before rename, and optional
+// mode preservation. Mirrors the discipline used by the caveman hook's
+// safeWriteFlag: an attacker who can pre-create the (predictable) temp path as
+// a symlink should not be able to redirect our write.
+//
+// preserveMode: if the target file already exists, copy its mode to the new
+// file instead of using `mode`. Used for settings.json so a user who set 0644
+// deliberately keeps that.
+
+export function safeAtomicWrite(
+  targetPath: string,
+  content: string,
+  options: { mode: number; preserveMode?: boolean } = { mode: 0o600 },
+): void {
+  const dir = path.dirname(targetPath)
+  fs.mkdirSync(dir, { recursive: true })
+
+  // Use a per-invocation tmp name so the path isn't a fixed attacker target.
+  const tmp = path.join(dir, `.${path.basename(targetPath)}.cc-forge-tmp.${process.pid}.${Date.now()}`)
+
+  // Decide effective mode: caller default, or preserve existing target mode.
+  let mode = options.mode
+  if (options.preserveMode) {
+    try {
+      const st = fs.statSync(targetPath)
+      // mask to permission bits
+      mode = st.mode & 0o777
+    } catch {
+      // target doesn't exist — fall through to default mode
+    }
+  }
+
+  // Best-effort: remove any leftover tmp at this exact path before open.
+  // O_EXCL means open will fail if it exists, which is what we want, but a
+  // stale tmp from a crashed prior run would block legitimate writes — so
+  // clean it up first if it exists and is a regular file we own.
+  try {
+    const st = fs.lstatSync(tmp)
+    if (st.isFile()) fs.unlinkSync(tmp)
+  } catch {
+    // ENOENT is fine
+  }
+
+  const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | O_NOFOLLOW
+  let fd: number | undefined
+  try {
+    fd = fs.openSync(tmp, flags, mode)
+    fs.writeSync(fd, content)
+    try { fs.fsyncSync(fd) } catch { /* best-effort durability */ }
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd)
+  }
+  fs.renameSync(tmp, targetPath)
+}

--- a/src/settings-patcher.ts
+++ b/src/settings-patcher.ts
@@ -1,0 +1,216 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import * as manifest from './manifest.js'
+import { safeAtomicWrite } from './safe-fs.js'
+
+const SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json')
+
+export interface HookEntryConfig {
+  event: string
+  command: string
+  timeout?: number
+}
+
+interface SettingsHookHandler {
+  type: 'command'
+  command: string
+  timeout?: number
+}
+
+interface SettingsHookGroup {
+  matcher?: string
+  hooks: SettingsHookHandler[]
+}
+
+interface SettingsShape {
+  hooks?: Record<string, SettingsHookGroup[]>
+  [k: string]: unknown
+}
+
+export class SettingsParseError extends Error {
+  constructor(public readonly underlying: unknown) {
+    super(
+      `~/.claude/settings.json is not valid JSON. Edit it (remove comments, trailing commas, or BOM) and re-run \`cc-forge install\`. Underlying error: ${String(underlying)}`,
+    )
+    this.name = 'SettingsParseError'
+  }
+}
+
+function readSettings(): SettingsShape {
+  if (!fs.existsSync(SETTINGS_PATH)) return {}
+  const raw = fs.readFileSync(SETTINGS_PATH, 'utf8')
+  if (raw.trim().length === 0) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (e) {
+    throw new SettingsParseError(e)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new SettingsParseError(new Error('settings.json must be a JSON object'))
+  }
+  return parsed as SettingsShape
+}
+
+function writeSettingsAtomic(obj: SettingsShape): void {
+  // preserveMode: settings.json is the user's file. Don't tighten 0644 to 0600
+  // silently if they set it deliberately for another tool to read.
+  safeAtomicWrite(SETTINGS_PATH, JSON.stringify(obj, null, 2), { mode: 0o600, preserveMode: true })
+}
+
+function resolveCommand(command: string): string {
+  if (command.startsWith('~/')) {
+    return path.join(os.homedir(), command.slice(2))
+  }
+  return path.resolve(command)
+}
+
+// --- Plan / commit split (for --dry-run) ---------------------------------
+
+export interface AddPlan {
+  kind: 'add'
+  alreadyPresent: boolean
+  event: string
+  command: string
+  timeout?: number
+}
+
+export interface RemovePlan {
+  kind: 'remove'
+  uuid: string
+  event: string
+  command: string
+}
+
+export function planAddHookEntry(cfg: HookEntryConfig): AddPlan {
+  const resolved = resolveCommand(cfg.command)
+  const existing = manifest.findEntry(
+    e => e.kind === 'settings-hook' && e.event === cfg.event && e.commandPath === resolved,
+  )
+  return {
+    kind: 'add',
+    alreadyPresent: existing !== undefined,
+    event: cfg.event,
+    command: resolved,
+    timeout: cfg.timeout,
+  }
+}
+
+export function commitAddHookEntry(cfg: HookEntryConfig): { alreadyPresent: boolean; entry: manifest.ManifestEntry } {
+  const plan = planAddHookEntry(cfg)
+  if (plan.alreadyPresent) {
+    const existing = manifest.findEntry(
+      e => e.kind === 'settings-hook' && e.event === plan.event && e.commandPath === plan.command,
+    )
+    if (!existing) throw new Error('Internal: alreadyPresent=true but manifest entry missing')
+    return { alreadyPresent: true, entry: existing }
+  }
+
+  // Snapshot pre-mutation settings so we can roll back if the manifest write
+  // fails after the settings.json write succeeds. Without this, settings.json
+  // can hold a hook entry the manifest does not own.
+  const preMutation = readSettings()
+  const settings = JSON.parse(JSON.stringify(preMutation)) as SettingsShape
+
+  settings.hooks = settings.hooks || {}
+  const groups = settings.hooks[plan.event] || []
+  groups.push({
+    matcher: '',
+    hooks: [
+      {
+        type: 'command',
+        command: plan.command,
+        ...(plan.timeout !== undefined ? { timeout: plan.timeout } : {}),
+      },
+    ],
+  })
+  settings.hooks[plan.event] = groups
+
+  writeSettingsAtomic(settings)
+  let entry: manifest.ManifestEntry
+  try {
+    entry = manifest.addEntry({
+      kind: 'settings-hook',
+      event: plan.event,
+      commandPath: plan.command,
+    })
+  } catch (manifestErr) {
+    // Roll back the settings.json write so the two stores stay consistent.
+    try {
+      writeSettingsAtomic(preMutation)
+    } catch (rollbackErr) {
+      throw new Error(
+        `Manifest write failed AND settings.json rollback failed. settings.json may have an orphan entry. Original: ${String(manifestErr)}. Rollback: ${String(rollbackErr)}`,
+      )
+    }
+    throw manifestErr
+  }
+  return { alreadyPresent: false, entry }
+}
+
+export function planRemoveHookEntry(uuid: string): RemovePlan | null {
+  const entry = manifest.findEntry(e => e.uuid === uuid)
+  if (!entry || entry.kind !== 'settings-hook') return null
+  return {
+    kind: 'remove',
+    uuid,
+    event: entry.event,
+    command: entry.commandPath,
+  }
+}
+
+export function commitRemoveHookEntry(uuid: string): RemovePlan | null {
+  const plan = planRemoveHookEntry(uuid)
+  if (!plan) return null
+
+  // Snapshot settings.json so we can roll back on manifest failure. Filtering
+  // is a no-op when the entry isn't present, which is the legitimate "already
+  // cleaned outside cc-forge" case — no extra branch needed.
+  const preMutation = readSettings()
+  const settings = JSON.parse(JSON.stringify(preMutation)) as SettingsShape
+  const groups = settings.hooks?.[plan.event] || []
+  const filtered = groups
+    .map(g => ({
+      ...g,
+      hooks: (g.hooks || []).filter(h => h.command !== plan.command),
+    }))
+    .filter(g => g.hooks.length > 0)
+
+  if (settings.hooks) {
+    if (filtered.length === 0) {
+      delete settings.hooks[plan.event]
+      if (Object.keys(settings.hooks).length === 0) delete settings.hooks
+    } else {
+      settings.hooks[plan.event] = filtered
+    }
+  }
+  writeSettingsAtomic(settings)
+
+  try {
+    manifest.removeEntry(uuid)
+  } catch (manifestErr) {
+    try {
+      writeSettingsAtomic(preMutation)
+    } catch (rollbackErr) {
+      throw new Error(
+        `Manifest update failed AND settings.json rollback failed. Original: ${String(manifestErr)}. Rollback: ${String(rollbackErr)}`,
+      )
+    }
+    throw manifestErr
+  }
+  return plan
+}
+
+// --- Read helpers for doctor ---------------------------------------------
+
+export function isWiredForEntry(entry: manifest.ManifestEntry): boolean {
+  if (!fs.existsSync(SETTINGS_PATH)) return false
+  try {
+    const settings = readSettings()
+    const groups = settings.hooks?.[entry.event] || []
+    return groups.some(g => g.hooks?.some(h => h.command === entry.commandPath))
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `/caveman` terse-response skill (lite/full/ultra levels) adapted from JuliusBrussee/caveman (MIT)
- Mode persists across turns via a `UserPromptSubmit` hook that writes a flag file and re-injects a reminder on every prompt
- Manifest-driven install/uninstall tracks cc-forge-owned `settings.json` entries (UUID-keyed) for clean removal
- Atomic writes throughout (O_NOFOLLOW, temp+rename, fsync) for symlink-safe flag and manifest I/O
- `--dry-run` / `--yes` / `--json` flags added to install, uninstall, doctor

Closes #28

## Test plan

- [x] `npm run build && node dist/cli.mjs install --dry-run` shows planned changes without writing
- [ ] `node dist/cli.mjs install --yes` wires hook idempotently
- [ ] `node dist/cli.mjs doctor --json` returns `"ok": true` with caveman report
- [ ] `/caveman ultra` activates; subsequent prompts include terse reminder
- [x] `stop caveman` deactivates; flag file removed
- [ ] Pasted text containing "caveman" mid-prompt does not toggle mode (head anchoring)
- [x] `node dist/cli.mjs uninstall --dry-run` shows manifest entries without touching anything
- [ ] `node dist/cli.mjs uninstall` removes hook, manifest, settings.json entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)