### PR TITLE
refactor: rename branch skill to branch-from-issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/initiative` - Author, maintain, and optionally publish a living high-level initiative doc at `docs/initiatives/`. One altitude up from `/plan` (workstreams, not commit-sized units). Two modes: invoke with no path to author a new initiative; invoke with the path to an existing initiative doc to resume — the skill gathers repo evidence since `last_updated` and writes the update back surgically. After either mode, offers to publish to GitHub as a parent issue with linked sub-tasks. Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiative <path>` to log progress.
 
 **GitHub Integration:**
-- `/branch` - Create and checkout a branch from an issue number (auto-detects repo)
+- `/branch-from-issue` - Create and checkout a git branch from an issue number (auto-detects repo)
 - `/issue-from-context` - Create GitHub issues from conversation context (auto-detects repo)
 - `/ship` - Commit changes, push branch, and create a PR (auto-detects repo)
 - `/land` - Pre-merge step run on an open PR. Resolves the open PR for the current branch (or pass a PR number), lets you pick the directory it most affected, prepends a capped (newest-10, FIFO) provenance entry — PR link + plan link + a one-line summary it writes — to that directory's `CLAUDE.md` `## Related` section, refreshes the body prose, then commits and pushes the update onto the PR's branch so the doc change merges with the same PR. Run it just before merging; never merges the PR itself.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiat
 
 | Skill | What it does | When to use |
 |---|---|---|
-| `/branch` | Creates and checks out a branch from an issue number or conversation context | Starting work tied to an issue |
+| `/branch-from-issue` | Creates and checks out a git branch from an issue number or conversation context | Starting work tied to an issue |
 | `/issue-from-context` | Generates a GitHub issue from conversation context and adds it to a project | Something worth tracking surfaced mid-conversation |
 | `/read-issue` | Fetches a GitHub issue by number and presents a structured digest | You want an issue's content summarized in-session |
 | `/triage-issue` | Fetches an issue and investigates the codebase to determine if it's still present, fixed, or needs more digging; writes to `docs/triage/` | Verifying whether a reported issue still reproduces |
@@ -164,7 +164,7 @@ Restart Claude Code. The hook reads a flag file at `~/.claude/.caveman-active` (
 
 **GitHub workflow:**
 ```
-/branch <issue-number> → /work → /ship → /land
+/branch-from-issue <issue-number> → /work → /ship → /land
 ```
 
 ## Structure

--- a/skills/branch-from-issue/SKILL.md
+++ b/skills/branch-from-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: branch
-description: Create and checkout a new branch from an issue number or conversation context
+name: branch-from-issue
+description: Create and checkout a new git branch from an issue number or conversation context
 disable-model-invocation: true
 user-invocable: true
 argument-hint: "[issue-number]"

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -13,7 +13,7 @@ Push the current branch and create a pull request. Also stage and commit any lin
 2. Run `git branch --show-current` to get the current branch name.
 
 **If the current branch is `main` or `master`, STOP immediately** and tell the user:
-> "You're on the main branch. Please check out a feature branch first before using /ship. Try using /branch"
+> "You're on the main branch. Please check out a feature branch first before using /ship. Try using /branch-from-issue"
 
 Do NOT proceed with any commits or pushes on main/master.
 


### PR DESCRIPTION
### Primary Changes
- ✏️ **Rename `/branch` → `/branch-from-issue`:** The bare `branch` name collided with Claude Code's built-in `/branch` (conversation branching), producing duplicate command entries. Renaming removes the shadow.
- 🔗 **Update references:** `ship` SKILL.md guidance message, README (skill table + workflow example), CLAUDE.md skill list.

---

### Test Plan
- [ ] After plugin refresh, `/branch-from-issue` appears once; no bare `/branch` cc-forge entry
- [ ] Built-in `/branch` (conversation) no longer ambiguous with cc-forge
- [ ] `/ship` on main shows the updated guidance message

Generated with [Claude Code](https://claude.com/claude-code)