### PR TITLE
refactor: rename review skill to deep-review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,13 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/brainstorm` - Explore requirements and approaches
 - `/plan` - Create implementation plans
 - `/work` - Execute work plans
-- `/review` - Multi-agent code review
+- `/deep-review` - Multi-agent code review (writes a review doc)
 - `/compound` - Document learnings
 - `/ideate` - Generate improvement ideas
 - `/deepen-plan` - Enhance plans with research
 - `/document-review` - Review requirement/plan docs
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
-- `/review-walk` - Guided execution of a `/review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
+- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
 - `/caveman` - Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook that re-injects a reminder when active. Off by default. Activate with `/caveman <level>`; deactivate with `/caveman off`, "stop caveman", or "normal mode".
 
 **Strategic:**

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Restart Claude Code after copying. Skills become available as `/<name>` slash co
 | `/plan` | Turns a feature description or requirements doc into a structured implementation plan grounded in repo patterns | Requirements are roughly defined and you need a technical approach broken into units |
 | `/deepen-plan` | Stress-tests an existing plan and selectively strengthens weak sections with targeted research | A Standard/Deep or high-risk plan needs more confidence around decisions, sequencing, or risk |
 | `/work` | Executes a work plan unit-by-unit, following repo patterns and testing as it goes | You have a plan and want it implemented |
-| `/review` | Exhaustive multi-agent code review using worktrees | Complex, risky, or large changes that warrant deep review |
-| `/review-walk` | Walks a `/review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable | You have a `docs/reviews/*.md` and want to act on it methodically |
+| `/deep-review` | Exhaustive multi-agent code review using worktrees; writes a structured review doc | Complex, risky, or large changes that warrant deep review |
+| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable | You have a `docs/reviews/*.md` and want to act on it methodically |
 | `/compound` | Documents a recently solved problem so the knowledge compounds | Right after solving something non-obvious worth recording |
 | `/ideate` | Generates and critically evaluates grounded improvement ideas for the project | "What should I improve?" — you want AI-generated directions before brainstorming one |
 | `/document-review` | Reviews a requirements or plan doc with parallel persona agents | A requirements/plan doc exists and you want role-specific critique |

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: review
-description: Perform exhaustive code reviews using multi-agent analysis, ultra-thinking, and worktrees
+name: deep-review
+description: Perform exhaustive multi-agent code reviews with ultra-thinking and worktrees, producing a structured review document
 argument-hint: "[PR number, GitHub URL, branch name, or latest] [--serial]"
 ---
 

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -2,7 +2,7 @@
 name: review-walk
 description: >
   Walk through a code-review document interactively. Reads a review file produced by
-  /review, presents related issues group-by-group with a plain-English teach moment
+  /deep-review, presents related issues group-by-group with a plain-English teach moment
   per group, then steps through each member issue offering implement / defer / skip /
   explain more. Updates `Status:` inline in the doc so progress is durable and
   resumable. Triggers on phrases like "walk the review", "step through the review",
@@ -19,7 +19,7 @@ For each group, teach the underlying concept in plain English before stepping in
 specific fixes. The review document is the source of truth — `Status:` updates live
 in the doc, so walks resume cleanly across sessions.
 
-This skill **consumes** review docs produced by `/review`. It does not run reviewers
+This skill **consumes** review docs produced by `/deep-review`. It does not run reviewers
 or produce new findings.
 
 ## Step 1: Resolve the Doc Path
@@ -35,7 +35,7 @@ or produce new findings.
   sort picks the most recent doc deterministically (no `mtime` ambiguity if the file
   was edited mid-walk).
 
-- If no review docs exist, STOP and tell the user to run `/review` first.
+- If no review docs exist, STOP and tell the user to run `/deep-review` first.
 - Confirm the resolved path back to the user before continuing:
   > "Walking review: `docs/reviews/<file>.md`. Proceed?"
   Use `AskUserQuestion` with Yes / Cancel.
@@ -268,7 +268,7 @@ When running in fallback mode (no `## Groups` section or no enriched fields):
   "defer").
 - The review doc is the source of truth. If the user manually edits the doc
   between turns, re-read it before the next action so changes are picked up.
-- Respect the Protected Artifacts rule from `/review`: never apply a fix that would
+- Respect the Protected Artifacts rule from `/deep-review`: never apply a fix that would
   delete or gitignore files under `docs/brainstorms/`, `docs/plans/`, or
   `docs/solutions/`. If such an issue slipped through, treat it as automatic
   `wont-fix` and warn the user.


### PR DESCRIPTION
### Primary Changes
- ✏️ **Rename `/review` → `/deep-review`:** The bare `review` name collided with Claude Code's built-in `/review` (quick PR review). This skill is the heavyweight multi-agent review-to-doc workflow; renaming removes the shadow and signals the difference in depth/cost.
- 🔗 **Update references:** `review-walk` (consumes deep-review docs), README skill table, CLAUDE.md skill list + review-walk description.

### What differs from built-in /review
- Built-in: single-pass inline PR review.
- `/deep-review`: parallel review agents, worktrees, ultra-thinking, writes a structured `docs/reviews/*.md` that `/review-walk` steps through.

---

### Test Plan
- [ ] After plugin refresh, `/deep-review` appears once; no bare `/review` cc-forge entry
- [ ] Built-in `/review` no longer ambiguous with cc-forge
- [ ] `/review-walk` still finds and walks `docs/reviews/*.md`

Generated with [Claude Code](https://claude.com/claude-code)