### PR TITLE
chore: rename colliding skills + credit compound-engineering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/initiative` - Author, maintain, and optionally publish a living high-level initiative doc at `docs/initiatives/`. One altitude up from `/plan` (workstreams, not commit-sized units). Two modes: invoke with no path to author a new initiative; invoke with the path to an existing initiative doc to resume — the skill gathers repo evidence since `last_updated` and writes the update back surgically. After either mode, offers to publish to GitHub as a parent issue with linked sub-tasks. Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiative <path>` to log progress.
 
 **GitHub Integration:**
-- `/branch` - Create and checkout a branch from an issue number (auto-detects repo)
+- `/branch-from-issue` - Create and checkout a git branch from an issue number (auto-detects repo)
 - `/issue-from-context` - Create GitHub issues from conversation context (auto-detects repo)
 - `/ship` - Commit changes, push branch, and create a PR (auto-detects repo)
 - `/land` - Pre-merge step run on an open PR. Resolves the open PR for the current branch (or pass a PR number), lets you pick the directory it most affected, prepends a capped (newest-10, FIFO) provenance entry — PR link + plan link + a one-line summary it writes — to that directory's `CLAUDE.md` `## Related` section, refreshes the body prose, then commits and pushes the update onto the PR's branch so the doc change merges with the same PR. Run it just before merging; never merges the PR itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,13 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/brainstorm` - Explore requirements and approaches
 - `/plan` - Create implementation plans
 - `/work` - Execute work plans
-- `/review` - Multi-agent code review
+- `/deep-review` - Multi-agent code review (writes a review doc)
 - `/compound` - Document learnings
 - `/ideate` - Generate improvement ideas
 - `/deepen-plan` - Enhance plans with research
 - `/document-review` - Review requirement/plan docs
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
-- `/review-walk` - Guided execution of a `/review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
+- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
 - `/caveman` - Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook that re-injects a reminder when active. Off by default. Activate with `/caveman <level>`; deactivate with `/caveman off`, "stop caveman", or "normal mode".
 
 **Strategic:**

--- a/README.md
+++ b/README.md
@@ -179,4 +179,6 @@ docs/            Plans, brainstorms, reviews, initiatives generated at runtime
 
 ## Credits
 
+cc-forge was originally scaffolded from [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) by [Every Inc](https://every.to) (Kieran Klaassen, T.M. Chow), MIT-licensed. The core `brainstorm → plan → work → review → compound` workflow, the research/review/workflow agent categories, and several skills derive from that project; cc-forge adapts and extends them for personal use. Credit and thanks to the compound-engineering authors for the foundation.
+
 The `/caveman` skill prompt is adapted from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) under the MIT license. The persistence hook (`hooks/cc-forge-caveman-mode-tracker.cjs`) is an original cc-forge implementation that lifts the symlink-safe flag-file primitives from upstream. The flag file path (`~/.claude/.caveman-active`) is shared between cc-forge and upstream caveman, so installing both will coexist on the same state, with cc-forge using a strict `{lite, full, ultra}` whitelist.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiat
 
 | Skill | What it does | When to use |
 |---|---|---|
-| `/branch` | Creates and checks out a branch from an issue number or conversation context | Starting work tied to an issue |
+| `/branch-from-issue` | Creates and checks out a git branch from an issue number or conversation context | Starting work tied to an issue |
 | `/issue-from-context` | Generates a GitHub issue from conversation context and adds it to a project | Something worth tracking surfaced mid-conversation |
 | `/read-issue` | Fetches a GitHub issue by number and presents a structured digest | You want an issue's content summarized in-session |
 | `/triage-issue` | Fetches an issue and investigates the codebase to determine if it's still present, fixed, or needs more digging; writes to `docs/triage/` | Verifying whether a reported issue still reproduces |
@@ -164,7 +164,7 @@ Restart Claude Code. The hook reads a flag file at `~/.claude/.caveman-active` (
 
 **GitHub workflow:**
 ```
-/branch <issue-number> → /work → /ship → /land
+/branch-from-issue <issue-number> → /work → /ship → /land
 ```
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Restart Claude Code after copying. Skills become available as `/<name>` slash co
 | `/plan` | Turns a feature description or requirements doc into a structured implementation plan grounded in repo patterns | Requirements are roughly defined and you need a technical approach broken into units |
 | `/deepen-plan` | Stress-tests an existing plan and selectively strengthens weak sections with targeted research | A Standard/Deep or high-risk plan needs more confidence around decisions, sequencing, or risk |
 | `/work` | Executes a work plan unit-by-unit, following repo patterns and testing as it goes | You have a plan and want it implemented |
-| `/review` | Exhaustive multi-agent code review using worktrees | Complex, risky, or large changes that warrant deep review |
-| `/review-walk` | Walks a `/review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable | You have a `docs/reviews/*.md` and want to act on it methodically |
+| `/deep-review` | Exhaustive multi-agent code review using worktrees; writes a structured review doc | Complex, risky, or large changes that warrant deep review |
+| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable | You have a `docs/reviews/*.md` and want to act on it methodically |
 | `/compound` | Documents a recently solved problem so the knowledge compounds | Right after solving something non-obvious worth recording |
 | `/ideate` | Generates and critically evaluates grounded improvement ideas for the project | "What should I improve?" — you want AI-generated directions before brainstorming one |
 | `/document-review` | Reviews a requirements or plan doc with parallel persona agents | A requirements/plan doc exists and you want role-specific critique |

--- a/skills/branch-from-issue/SKILL.md
+++ b/skills/branch-from-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: branch
-description: Create and checkout a new branch from an issue number or conversation context
+name: branch-from-issue
+description: Create and checkout a new git branch from an issue number or conversation context
 disable-model-invocation: true
 user-invocable: true
 argument-hint: "[issue-number]"

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: review
-description: Perform exhaustive code reviews using multi-agent analysis, ultra-thinking, and worktrees
+name: deep-review
+description: Perform exhaustive multi-agent code reviews with ultra-thinking and worktrees, producing a structured review document
 argument-hint: "[PR number, GitHub URL, branch name, or latest] [--serial]"
 ---
 

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -2,7 +2,7 @@
 name: review-walk
 description: >
   Walk through a code-review document interactively. Reads a review file produced by
-  /review, presents related issues group-by-group with a plain-English teach moment
+  /deep-review, presents related issues group-by-group with a plain-English teach moment
   per group, then steps through each member issue offering implement / defer / skip /
   explain more. Updates `Status:` inline in the doc so progress is durable and
   resumable. Triggers on phrases like "walk the review", "step through the review",
@@ -19,7 +19,7 @@ For each group, teach the underlying concept in plain English before stepping in
 specific fixes. The review document is the source of truth — `Status:` updates live
 in the doc, so walks resume cleanly across sessions.
 
-This skill **consumes** review docs produced by `/review`. It does not run reviewers
+This skill **consumes** review docs produced by `/deep-review`. It does not run reviewers
 or produce new findings.
 
 ## Step 1: Resolve the Doc Path
@@ -35,7 +35,7 @@ or produce new findings.
   sort picks the most recent doc deterministically (no `mtime` ambiguity if the file
   was edited mid-walk).
 
-- If no review docs exist, STOP and tell the user to run `/review` first.
+- If no review docs exist, STOP and tell the user to run `/deep-review` first.
 - Confirm the resolved path back to the user before continuing:
   > "Walking review: `docs/reviews/<file>.md`. Proceed?"
   Use `AskUserQuestion` with Yes / Cancel.
@@ -268,7 +268,7 @@ When running in fallback mode (no `## Groups` section or no enriched fields):
   "defer").
 - The review doc is the source of truth. If the user manually edits the doc
   between turns, re-read it before the next action so changes are picked up.
-- Respect the Protected Artifacts rule from `/review`: never apply a fix that would
+- Respect the Protected Artifacts rule from `/deep-review`: never apply a fix that would
   delete or gitignore files under `docs/brainstorms/`, `docs/plans/`, or
   `docs/solutions/`. If such an issue slipped through, treat it as automatic
   `wont-fix` and warn the user.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -13,7 +13,7 @@ Push the current branch and create a pull request. Also stage and commit any lin
 2. Run `git branch --show-current` to get the current branch name.
 
 **If the current branch is `main` or `master`, STOP immediately** and tell the user:
-> "You're on the main branch. Please check out a feature branch first before using /ship. Try using /branch"
+> "You're on the main branch. Please check out a feature branch first before using /ship. Try using /branch-from-issue"
 
 Do NOT proceed with any commits or pushes on main/master.
 


### PR DESCRIPTION
Consolidates three small follow-ups into one PR (supersedes #35, #36, #37).

### Primary Changes
- ✏️ **Rename `/branch` → `/branch-from-issue`:** removes the collision with Claude Code's built-in `/branch` (conversation branching).
- ✏️ **Rename `/review` → `/deep-review`:** removes the collision with the built-in `/review` (quick PR review). This is the heavyweight multi-agent review-to-doc skill; the new name signals the difference. References updated in `review-walk`, README, CLAUDE.md.
- 📝 **Credit compound-engineering:** README Credits now attributes [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) (Every Inc, MIT) as the project's basis.

### Test Plan
- [ ] After plugin refresh, `/branch-from-issue` and `/deep-review` appear once; no bare `/branch` or `/review` cc-forge entries
- [ ] `/review-walk` still finds and walks `docs/reviews/*.md`
- [ ] README Credits links compound-engineering

Generated with [Claude Code](https://claude.com/claude-code)