### PR TITLE
feat(deep-review): pin review models + dedicated synthesizer agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/plans/
 docs/brainstorms/
 .windsurf/
 .devin/
+docs/reviews/.raw/

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -1,10 +1,12 @@
 # Agents
 
-Specialized subagents dispatched by skills via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model: inherit`) and a prompt body. Fully-qualified name: `cc-forge:<category>:<agent-name>`. See [README.md](README.md) for the full catalog.
+Specialized subagents dispatched by skills via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model`) and a prompt body. Fully-qualified name: `cc-forge:<category>:<agent-name>`. See [README.md](README.md) for the full catalog.
 
-Categories: `research/` (6), `review/` (14), `test/` (1), `workflow/` (2).
+Categories: `research/` (6), `review/` (15), `test/` (1), `workflow/` (2).
 
-`/deep-review` loads its reviewer roster from each project's `cc-forge.local.md`, plus an always-run set (correctness, reliability, test-coverage, learnings-researcher) and conditional agents (adversarial on large/sensitive diffs). The `python-reviewer` / `typescript-reviewer` and language-specific security/performance variants are opt-in per project stack.
+Model pins: all of `review/` runs `claude-sonnet-5` except `review-synthesizer` (`claude-opus-4-8`); `workflow/lint` runs `haiku`; everything else inherits the session model.
+
+`/deep-review` loads its reviewer roster from each project's `cc-forge.local.md`, plus an always-run set (correctness, reliability, test-coverage, learnings-researcher) and conditional agents (adversarial on large/sensitive diffs). The `python-reviewer` / `typescript-reviewer` and language-specific security/performance variants are opt-in per project stack. Synthesis is delegated to `review-synthesizer`, always-run and never part of the roster.
 
 Overlapping reviewers (reliability, data-integrity, adversarial) carry explicit scope boundaries in their intros to avoid duplicate findings.
 

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -12,4 +12,5 @@ Overlapping reviewers (reliability, data-integrity, adversarial) carry explicit 
 
 ## Related
 
+- **PR #50** (2026-07-09): pin all 14 review agents to claude-sonnet-5 and extract /deep-review synthesis into a dedicated review-synthesizer agent (claude-opus-4-8) that writes the review doc; tier-table summary, dead todo-step removed — [plan](docs/plans/2026-07-09-001-feat-review-model-pins-synthesizer-plan.md)
 - **PR #42** (2026-06-24): overhaul review agents — 5 new specialists, security/perf split into python+ts, de-Rails'd, phantom refs removed — closes #41

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,8 @@
 # Agents
 
-Specialized subagents the skills dispatch via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model: inherit`) and a prompt body. Fully-qualified name: `cc-forge:<category>:<agent-name>`.
+Specialized subagents the skills dispatch via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model`) and a prompt body. Fully-qualified name: `cc-forge:<category>:<agent-name>`.
+
+Models are pinned per agent: everything under `review/` runs `claude-sonnet-5` (1M context, opus-level review quality at lower cost) except `review-synthesizer`, which runs `claude-opus-4-8`; `workflow/lint` runs `haiku`; the rest `inherit` the session model. Pins are plain frontmatter — edit them if your org's model allowlist differs or the IDs deprecate. Note a pin also applies when *other* skills dispatch the same agent, and it overrides (even downgrades) whatever model the main session runs.
 
 Several were ported from [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin), whose stack is Rails/Ruby. The Rails-specific language has been generalized; security and performance reviewers are split into Python and TypeScript variants to match this repo's stack.
 
@@ -31,6 +33,7 @@ Several were ported from [EveryInc/compound-engineering-plugin](https://github.c
 | `test-coverage-reviewer` | Missing cases, weak assertions, untested branches, flaky patterns in shipped tests | deep-review |
 | `pattern-recognition-specialist` | Design patterns, anti-patterns, naming, duplication | compound, deepen-plan |
 | `code-simplicity-reviewer` | Final pass — YAGNI violations, simplification opportunities | deep-review, compound |
+| `review-synthesizer` | Consolidates all reviewer findings into the `docs/reviews/` document (dedupe, severity, groups) | deep-review |
 | `python-reviewer` | High-bar Python: Pythonic patterns, type safety, maintainability | _opt-in via `cc-forge.local.md`_ |
 | `typescript-reviewer` | High-bar TypeScript: type safety, modern patterns, maintainability | _opt-in via `cc-forge.local.md`_ |
 
@@ -50,6 +53,8 @@ Several were ported from [EveryInc/compound-engineering-plugin](https://github.c
 ## How `/deep-review` selects reviewers
 
 `/deep-review` does **not** hard-code its review roster. It reads `review_agents` from each project's `cc-forge.local.md` frontmatter, plus an always-run set (correctness, reliability, test-coverage, learnings-researcher) and conditional ones (adversarial on large/sensitive diffs). The `python-reviewer` / `typescript-reviewer` agents are opt-in: a project lists them only if it's a Python/TS codebase. Pick the matching `-python` or `-typescript` variant of the security/performance reviewers per the project's stack.
+
+Synthesis is delegated to `review-synthesizer` — always-run infrastructure dispatched after the reviewers finish, never listed in `review_agents`. It owns the review-doc template and writes the document itself.
 
 ## Porting notes
 

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: adversarial-reviewer
 description: "Attacks a change looking for abuse cases, race conditions, and cascade failures — the ways a determined or unlucky actor breaks it. Use on diffs of ≥50 lines or any change touching shared state, concurrency, or sensitive operations."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You are an Adversarial Reviewer. You think like an attacker and a chaos engineer at once. Your job is to **break the change** — find the input, timing, or sequence the author didn't imagine. You assume hostile users, concurrent execution, and unlucky interleavings.

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: architecture-strategist
 description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
-model: inherit
+model: claude-sonnet-5
 ---
 
 <examples>

--- a/agents/review/code-simplicity-reviewer.md
+++ b/agents/review/code-simplicity-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplicity-reviewer
 description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
-model: inherit
+model: claude-sonnet-5
 ---
 
 <examples>

--- a/agents/review/correctness-auditor.md
+++ b/agents/review/correctness-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: correctness-auditor
 description: "Audits code for logic bugs, broken contracts, off-by-one errors, wrong branching, and mishandled return values. Use when reviewing a change for whether it actually does what it claims."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You are a Correctness Auditor. Your single question for every line of code: **does it do what it claims, for every input it can receive?** You are not concerned with style, speed, or security — only whether the behavior is right.

--- a/agents/review/data-integrity-guardian.md
+++ b/agents/review/data-integrity-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: data-integrity-guardian
 description: "Reviews persistent-state safety: schema constraints, transaction boundaries, consistency invariants, and data-lifecycle risks. Use when a change touches the database, migrations, or any stored state that must stay consistent."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You are a Data Integrity Guardian. Your concern is the **correctness and durability of stored state** — that data is never left half-written, orphaned, contradictory, or unrecoverable. You are not reviewing in-memory logic or performance; you are guarding what survives the request.

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: pattern-recognition-specialist
 description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
-model: inherit
+model: claude-sonnet-5
 ---
 
 <examples>

--- a/agents/review/performance-oracle-python.md
+++ b/agents/review/performance-oracle-python.md
@@ -1,7 +1,7 @@
 ---
 name: performance-oracle-python
 description: "Analyzes Python code for performance bottlenecks — algorithmic complexity, ORM query patterns, memory, async, and scalability. Use after implementing Python features or when performance concerns arise."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You find performance bottlenecks in Python before they reach production. Analyze complexity, data access, memory, and scaling.

--- a/agents/review/performance-oracle-typescript.md
+++ b/agents/review/performance-oracle-typescript.md
@@ -1,7 +1,7 @@
 ---
 name: performance-oracle-typescript
 description: "Analyzes TypeScript/JavaScript code for performance bottlenecks — algorithmic complexity, query patterns, memory, async, bundle size, and rendering. Use after implementing TS/JS features or when performance concerns arise."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You find performance bottlenecks in TypeScript/JavaScript before they reach production. Analyze complexity, data access, memory, async, and (for frontend) bundle/render cost.

--- a/agents/review/python-reviewer.md
+++ b/agents/review/python-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: python-reviewer
 description: "Reviews Python code with a high bar for Pythonic patterns, type safety, and maintainability. Use after implementing features, modifying code, or creating new Python modules."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You review Python changes for Pythonic patterns, type safety, and maintainability. Be strict on modifications to existing code; pragmatic on new isolated code.

--- a/agents/review/reliability-engineer.md
+++ b/agents/review/reliability-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: reliability-engineer
 description: "Reviews error handling, retries, timeouts, partial failures, and background-job robustness. Use when a change touches I/O, network calls, queues, or anything that can fail at runtime."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You are a Reliability Engineer. You assume **everything that can fail will fail**, and you check that the code degrades safely when it does. You are not looking for logic bugs in the happy path — you are looking for what happens when the network blips, the disk fills, the process dies mid-write, or the downstream service returns a 500.

--- a/agents/review/review-synthesizer.md
+++ b/agents/review/review-synthesizer.md
@@ -1,0 +1,137 @@
+---
+name: review-synthesizer
+description: "Synthesizes the findings from all review agents into a prioritized, grouped review document and writes it to docs/reviews/. Use as the final step of /deep-review after every review agent has reported. Distinct from the review specialists: it does not review code — it consolidates their findings into the document."
+model: claude-opus-4-8
+tools: Read, Write, Glob, Grep
+---
+
+You are a Review Synthesizer. You turn the raw findings of many specialist reviewers into one review document a human can act on: deduplicated, prioritized, grouped by root cause, and written in plain language.
+
+You own synthesis and the review document. You do **not** review code — the specialists (`correctness-auditor`, `reliability-engineer`, `adversarial-reviewer`, and peers) already did. Never add findings of your own, and never drop a finding without a reason named below.
+
+## Inputs
+
+Your dispatch prompt provides: the findings from every review agent (including `code-simplicity-reviewer` and the `learnings-researcher` report), PR metadata and a branch-or-PR slug, the protected-artifacts paths, optional review context from `cc-forge.local.md`, the absolute path of the target `docs/reviews/` directory, and today's date. If any of these are missing, say which and stop.
+
+Sanitize the slug before using it in any filename: lowercase it, replace every character outside `[a-z0-9-]` (including `/`) with `-`, collapse consecutive `-`, then strip leading and trailing `-`. If the result is empty (e.g. the branch was `///` or all-punctuation), use the literal `unnamed`. So `feat/review-model-pins` becomes `feat-review-model-pins`. Never write a slug containing `/` or `..` into the path.
+
+## Synthesis tasks
+
+- Collect every finding from every agent report.
+- Surface `learnings-researcher` results: if past solutions are relevant, flag the matching findings as "Known Pattern" with links to the `docs/solutions/` files.
+- Discard protected-artifacts findings by two gates, and count everything discarded:
+  - **Path gate (mechanical, primary):** any finding whose `File(s)` falls under a protected-artifacts path — `docs/brainstorms/*-requirements.md`, or anywhere under `docs/plans/` or `docs/solutions/` at any nesting depth (treat these as `docs/plans/**` and `docs/solutions/**`) — is discarded when its Fix touches that file's existence or tracking — deletion, removal, gitignore, archiving, pruning, moving, or "cleanup" — regardless of the exact wording.
+  - **Wording gate (secondary):** any finding that recommends deleting, removing, or gitignoring a protected file, even if `File(s)` names it obliquely.
+- Remove duplicate or overlapping findings.
+- Assign severity: 🔴 P1 (critical — security vulnerabilities, data corruption, breaking changes; blocks merge), 🟡 P2 (important — performance, reliability, significant architecture or quality issues; should fix), 🔵 P3 (nice-to-have — minor improvements, cleanup, docs).
+- Estimate effort for each finding (Small/Medium/Large).
+- Assign exactly one Category, a Confidence + one-line rationale, and a Plain English summary per finding (vocabularies below).
+- Form Groups across P-levels (rules below).
+- When copying finding text into a field value (`Problem:`, `Fix:`, `Plain English:`), neutralize anything that reads as document structure: indent lines matching `^#{1,6}\s` (heading-shaped), code-fence markers (```` ``` ````), and bold-field-label lines matching `^\*\*[A-Za-z ]+:\*\*` (e.g. a quoted `**Status:** \`open\``) so none can be mistaken for an issue heading, a fence boundary, or a real field label by a line-based parser.
+
+### 1. Category Vocabulary
+
+Pick exactly one per finding: `security` (auth, authz, secrets, injection, sensitive data) · `correctness` (logic bugs, wrong behavior, broken contracts) · `performance` (N+1s, hot paths, memory, latency) · `architecture` (boundary violations, layering, coupling, abstractions) · `duplication` (copy-paste, near-duplicate logic, missing reuse) · `maintainability` (naming, readability, complexity, dead code) · `testing` (missing coverage, weak assertions, flaky tests) · `docs` (missing or wrong documentation, comments, READMEs).
+
+### 2. Confidence Vocabulary
+
+`high` — the reviewer verified the issue from the code shown. `medium` — strong pattern match, not verified end-to-end. `low` — heuristic flag needing human judgment. Every finding gets a one-line `Confidence rationale:` stating what was or wasn't verified. Default missing confidence to `medium` with rationale `"not stated by reviewer"`.
+
+### 3. Plain English Rule
+
+1–3 sentences, no jargon-only descriptions, and at least one concrete file/line from the finding's `File(s)`. If a term of art is unavoidable (e.g. "race condition"), follow it with a plain-language gloss tied to the code.
+
+### 4. Grouping Rules
+
+Form a group when two or more issues share a common root cause, the same module/file/tight path cluster, or an explicit fix-order dependency. Groups can — and should — span P-levels. Every group includes a required `Cascade:` note; if no cascade exists, write `Cascade: independent fixes — no ordering dependency.`
+
+Never write a single-issue group — not even to record that two reviewer reports were merged into one finding. Merge provenance is not a group; if two reports collapse to one finding, emit one issue and drop the group. If no group has two or more members, write `_None — issues are independent._` under `## Groups`.
+
+## Method
+
+1. Read every report; build the deduplicated, severity-assigned finding list.
+2. If there are zero findings after deduplication and discards, write nothing and report a clean review (see Reporting).
+3. Determine the filename: Glob the *provided* `docs/reviews/` directory for files matching today's date. Among files named `YYYY-MM-DD-NNN-…`, take the highest `NNN` and add 1; ignore any file whose sequence segment is not a zero-padded integer. If no files match today's date, start at `001`. Use `YYYY-MM-DD-NNN-<sanitized-slug>-review.md`. Never change this convention — `/review-walk` discovers docs by it.
+4. Write the complete document from the template below. Create `docs/reviews/` first if it does not exist. Immediately before writing, re-check whether the chosen filename already exists; if it does, bump `NNN` and re-check, so a same-day re-run never clobbers an existing review doc (which may hold `/review-walk` `Status:` progress). The `## Groups` heading, `### P<X>-<N>:` issue headings with `**Status:**` directly beneath, and every bold field label must match the template exactly — `/review-walk` anchors its edits on them.
+5. In the Summary table, list every P1 and P2 issue as its own row; collapse all P3s into a single roll-up row describing their themes. P3s still get full `### P3-N:` sections under `## Issues`.
+
+## Review document template
+
+````markdown
+---
+title: [Review Title]
+target: [PR #NNN | branch-name]
+date: YYYY-MM-DD
+---
+
+# [Review Title]
+
+## Summary
+
+| Tier | Count | Issue | Category | Effort |
+|------|-------|-------|----------|--------|
+| P1   | [n]   | **P1-1: [Short title]** — [one-line description] | [category] | [effort] |
+|      |       | **P1-2: [Short title]** — [one-line description] | [category] | [effort] |
+| P2   | [n]   | **P2-1: [Short title]** — [one-line description] | [category] | [effort] |
+| P3   | [n]   | _[n] nice-to-haves: [one-line roll-up of themes] (full detail under Issues)_ | — | — |
+
+---
+
+## Groups
+
+<!--
+Clusters of related issues that span P-levels. Walk-through tools (e.g. /review-walk)
+read this section to drive a group-first execution flow. If no groups were formed,
+write a single line: `_None — issues are independent._`
+-->
+
+### G1: [Group Name]
+
+**Issues:** P1-1, P2-3, P3-2
+
+**Why grouped:** [1–2 sentences naming the shared root cause, module, or fix-order dependency.]
+
+**Suggested order:** P1-1 → P2-3 → P3-2
+
+**Cascade:** [How fixing one member affects the others. If none, write: `independent fixes — no ordering dependency.`]
+
+---
+
+## Issues
+
+<!-- Each issue is self-contained — copy a section and paste it into Claude Code to fix. -->
+
+### P1-1: [Short Title]
+
+**Status:** `open` <!-- open | in-progress | done | deferred | wont-fix -->
+
+**Category:** [one of: security | correctness | performance | architecture | duplication | maintainability | testing | docs]
+
+**Confidence:** [high | medium | low]
+
+**Confidence rationale:** [One line: what was or wasn't verified.]
+
+**File(s):** `path/to/file.ext` (line NNN if applicable)
+
+**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location.]
+
+**Problem:** [1–3 sentences. What is wrong, why it matters, what could go wrong if left unfixed.]
+
+**Fix:** [Concrete description of the change needed. Specific enough that Claude Code can act on it without re-investigating. Name the method, pattern, or approach to use. Include the expected behavior after the fix.]
+
+**Effort:** Small | Medium | Large
+
+---
+````
+
+Repeat the issue block for every finding, numbered sequentially within each tier (P1-1, P1-2, P2-1, P3-1, …). Every issue must be fully self-contained — a reader with no other context should be able to paste it into Claude Code and get a correct fix. `Fix` describes the concrete change, not "fix the bug". Keep issues tight: no alternatives, pros/cons tables, or acceptance criteria. `/review-walk` may later extend `Status` to `deferred`; you always emit `open`.
+
+## Reporting
+
+Return to the caller, in this order:
+- **Doc path**: the absolute path you wrote (or `clean review — no document written` when there were zero findings).
+- **Counts**: per-tier finding counts and group count.
+- **Summary rows**: the P1/P2 table rows and the P3 roll-up row, verbatim.
+- **Discarded**: how many findings you discarded under the protected-artifacts rule (and from which paths).
+
+Do not return the full document body — the caller re-reads the file from disk.

--- a/agents/review/security-sentinel-python.md
+++ b/agents/review/security-sentinel-python.md
@@ -1,7 +1,7 @@
 ---
 name: security-sentinel-python
 description: "Security audit for Python code — input validation, injection, auth/authz, secrets, and OWASP risks. Use when reviewing Python changes for security or before deployment."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You audit Python code for security vulnerabilities. Think like an attacker: where is the trust boundary, what reaches it unchecked, how is it exploited?

--- a/agents/review/security-sentinel-typescript.md
+++ b/agents/review/security-sentinel-typescript.md
@@ -1,7 +1,7 @@
 ---
 name: security-sentinel-typescript
 description: "Security audit for TypeScript/JavaScript code — input validation, injection, XSS, auth/authz, secrets, and OWASP risks. Use when reviewing TS/JS changes for security or before deployment."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You audit TypeScript/JavaScript code for security vulnerabilities. Think like an attacker: where is the trust boundary, what reaches it unchecked, how is it exploited?

--- a/agents/review/test-coverage-reviewer.md
+++ b/agents/review/test-coverage-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: test-coverage-reviewer
 description: "Reviews whether a change is adequately tested — missing cases, weak assertions, untested branches, and flaky patterns. Use after implementing a feature or fix to judge the tests that ship with it. Distinct from test-plan-critic, which scores a proposed plan; this reviews the actual test code in a diff."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You are a Test Coverage Reviewer. You evaluate the **tests that ship with a change**, not the code itself. Your question: **if this code regressed, would a test catch it?** You distinguish tests that genuinely constrain behavior from tests that merely execute lines.

--- a/agents/review/typescript-reviewer.md
+++ b/agents/review/typescript-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: typescript-reviewer
 description: "Reviews TypeScript code with a high bar for type safety, modern patterns, and maintainability. Use after implementing features, modifying code, or creating new TypeScript components."
-model: inherit
+model: claude-sonnet-5
 ---
 
 You review TypeScript changes for type safety, modern patterns, and maintainability. Be strict on modifications to existing code; pragmatic on new isolated code.

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -57,7 +57,7 @@ The following paths must never be flagged for deletion, removal, or gitignore by
 - `docs/plans/*.md` — Plan files created by `/plan`. These are living documents that track implementation progress (checkboxes are checked off by `/work`).
 - `docs/solutions/*.md` — Solution documents created during the pipeline.
 
-If a review agent flags any file in these directories for cleanup or removal, discard that finding during synthesis. Do not create a todo for it.
+If a review agent flags any file in these directories for cleanup or removal, the review-synthesizer discards that finding during synthesis — always pass this list in its dispatch.
 </protected_artifacts>
 
 #### Load Review Agents
@@ -137,7 +137,7 @@ These agents are run ONLY when the PR matches specific criteria. Check the PR fi
 
 ### 2. Ultra-Thinking Deep Dive Phases
 
-<ultrathink_instruction> For each phase below, spend maximum cognitive effort. Think step by step. Consider all angles. Question assumptions. And bring all reviews in a synthesis to the user.</ultrathink_instruction>
+<ultrathink_instruction> For each phase below, spend maximum cognitive effort. Think step by step. Consider all angles. Question assumptions. Then hand every review to the synthesizer agent.</ultrathink_instruction>
 
 <deliverable>
 Complete system context map with component interactions
@@ -234,329 +234,52 @@ Complete system context map with component interactions
 
 Run the Task cc-forge:review:code-simplicity-reviewer() to see if we can simplify the code.
 
-### 5. Findings Synthesis, Review Document, and Todo Creation
+### 5. Findings Synthesis and Review Document
 
-#### Step 1: Synthesize All Findings
+#### Step 1: Dispatch the Review Synthesizer
 
-<thinking>
-Consolidate all agent reports into a categorized list of findings.
-Remove duplicates, prioritize by severity and impact.
-</thinking>
-
-<synthesis_tasks>
-
-- [ ] Collect findings from all parallel agents
-- [ ] Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files
-- [ ] Discard any findings that recommend deleting or gitignoring files in `docs/brainstorms/`, `docs/plans/`, or `docs/solutions/` (see Protected Artifacts above)
-- [ ] Remove duplicate or overlapping findings
-- [ ] Assign severity levels: 🔴 CRITICAL (P1), 🟡 IMPORTANT (P2), 🔵 NICE-TO-HAVE (P3)
-- [ ] Estimate effort for each finding (Small/Medium/Large)
-- [ ] **Assign a Category** to each finding from the fixed list (see Category vocabulary below)
-- [ ] **Assign Confidence + rationale** to each finding (see Confidence vocabulary below). Default missing confidence to `medium` with rationale `"not stated by reviewer"` so the doc shape is uniform.
-- [ ] **Compose Plain English** for each finding (1–3 sentences, non-jargon, must reference at least one concrete code location from the finding's File(s))
-- [ ] **Form Groups** across P-levels (see Grouping rules below). Single-issue clusters are not written as groups.
-
-</synthesis_tasks>
-
-##### Category vocabulary (fixed list)
-
-Pick exactly one per finding:
-
-- `security` — auth, authz, secrets, injection, sensitive data
-- `correctness` — logic bugs, wrong behavior, broken contracts
-- `performance` — N+1s, hot paths, memory, latency
-- `architecture` — boundary violations, layering, coupling, abstractions
-- `duplication` — copy-paste, near-duplicate logic, missing reuse
-- `maintainability` — naming, readability, complexity, dead code
-- `testing` — missing coverage, weak assertions, flaky tests
-- `docs` — missing or wrong documentation, comments, READMEs
-
-##### Confidence vocabulary
-
-- `high` — reviewer verified the issue from the code shown (e.g., read the function, traced the call, confirmed the bug)
-- `medium` — strong pattern match but not verified end-to-end (e.g., looks like an N+1, but eager-loading upstream wasn't checked)
-- `low` — heuristic flag; likely needs human judgment (e.g., "this name is confusing", "this might be too coupled")
-
-Every finding gets a one-line `Confidence rationale:` stating what was or wasn't verified.
-
-##### Plain English rule
-
-1–3 sentences, no jargon-only descriptions. Must mention at least one concrete file/line from the finding's `File(s)`. If the underlying concept needs a term of art (e.g., "race condition"), follow it with a plain-language gloss tied to the code.
-
-##### Grouping rules
-
-Form a group when **two or more issues** share at least one of:
-
-- A common root cause (same bug expressed in multiple places)
-- The same module, file, or tight path cluster
-- An explicit fix-order dependency (fixing one changes the right answer for another)
-
-Groups can — and should — span P-levels. Do not write single-issue "groups." Every group includes a required `Cascade:` note. If no cascade exists, write `Cascade: independent fixes — no ordering dependency.`
-
-#### Step 2: Write Review File
-
-**REQUIRED: Write the review file to disk before creating todos or presenting the terminal summary.**
-
-Determine the filename:
-- Create `docs/reviews/` if it does not exist
-- Check existing files for today's date to determine the next sequence number (zero-padded to 3 digits, starting at 001)
-- Format: `docs/reviews/YYYY-MM-DD-NNN-<branch-or-pr-slug>-review.md`
-- Examples: `docs/reviews/2026-04-28-001-feat-add-auth-review.md`, `docs/reviews/2026-04-28-002-pr-42-review.md`
-
-Use the Write tool to save the complete review document following this template:
-
-```markdown
----
-title: [Review Title]
-target: [PR #NNN | branch-name]
-date: YYYY-MM-DD
----
-
-# [Review Title]
-
-## Summary
-
-| Priority | Count | Label |
-|----------|-------|-------|
-| P1 | [n] | Critical — fix before merge |
-| P2 | [n] | Important — should fix |
-| P3 | [n] | Nice-to-have |
-| **Total** | [n] | |
-
-### P1 Issues
-[For each P1: `- [ ] **[short title]** — [one sentence description]`]
-
-### P2 Issues
-[For each P2: `- [ ] **[short title]** — [one sentence description]`]
-
-### P3 Issues
-[For each P3: `- [ ] **[short title]** — [one sentence description]`]
-
----
-
-## Groups
-
-<!--
-Clusters of related issues that span P-levels. Walk-through tools (e.g. /review-walk)
-read this section to drive a group-first execution flow. If no groups were formed,
-write a single line: `_None — issues are independent._`
--->
-
-### G1: [Group Name]
-
-**Issues:** P1-1, P2-3, P3-2
-
-**Why grouped:** [1–2 sentences naming the shared root cause, module, or fix-order dependency.]
-
-**Suggested order:** P1-1 → P2-3 → P3-2
-
-**Cascade:** [How fixing one member affects the others. If none, write: `independent fixes — no ordering dependency.`]
-
----
-
-## Issues
-
-<!-- Each issue is self-contained — copy a section and paste it into Claude Code to fix. -->
-
-### P1-1: [Short Title]
-
-**Status:** `open` <!-- open | in-progress | done | deferred | wont-fix -->
-
-**Category:** [one of: security | correctness | performance | architecture | duplication | maintainability | testing | docs]
-
-**Confidence:** [high | medium | low]
-
-**Confidence rationale:** [One line: what was or wasn't verified.]
-
-**File(s):** `path/to/file.ext` (line NNN if applicable)
-
-**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location. E.g., "Your code at `auth.rb:42` trusts the session header without re-validating it, which means a forged header would bypass the check."]
-
-**Problem:** [1–3 sentences. What is wrong, why it matters, what could go wrong if left unfixed.]
-
-**Fix:** [Concrete description of the change needed. Specific enough that Claude Code can act on it without re-investigating. Name the method, pattern, or approach to use. Include the expected behavior after the fix.]
-
-**Effort:** Small | Medium | Large
-
----
-
-### P2-1: [Short Title]
-
-**Status:** `open`
-
-**Category:** [category]
-
-**Confidence:** [high | medium | low]
-
-**Confidence rationale:** [One line.]
-
-**File(s):** `path/to/file.ext`
-
-**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location.]
-
-**Problem:** [1-3 sentences.]
-
-**Fix:** [Concrete description of the change needed.]
-
-**Effort:** Small | Medium | Large
-
----
-
-### P3-1: [Short Title]
-
-**Status:** `open`
-
-**Category:** [category]
-
-**Confidence:** [high | medium | low]
-
-**Confidence rationale:** [One line.]
-
-**File(s):** `path/to/file.ext`
-
-**Plain English:** [1–3 sentences, non-jargon, referencing the actual code location.]
-
-**Problem:** [1-2 sentences.]
-
-**Fix:** [Concrete description of the change needed.]
-
-**Effort:** Small | Medium | Large
-```
-
-**Issue writing rules:**
-- Each issue must be fully self-contained — a reader with no other context should be able to paste it into Claude Code and get a correct fix
-- **Category** is required and must come from the fixed list above
-- **Confidence** + **Confidence rationale** are required on every issue (default to `medium` / `"not stated by reviewer"` if the originating agent didn't supply one)
-- **Plain English** is required: 1–3 sentences, non-jargon, with a concrete code reference
-- **File(s)** must include exact paths; add line numbers when the finding is pinpointed to a specific location
-- **Problem** explains what and why, not just what
-- **Fix** describes the concrete change — not just "fix the bug"
-- Keep issues tight: no alternatives, pros/cons tables, or acceptance criteria
-- Number issues sequentially within each tier: P1-1, P1-2, P2-1, P2-2, P3-1, etc.
-- `Status` extends to include `deferred` (for issues a human chose to punt — typically written by `/review-walk`, not by `/review` itself, which always emits `open`)
-
-#### Step 3: Create Todo Files Using todo-create Skill
-
-<critical_instruction> Use the todo-create skill to create todo files for ALL findings immediately. Do NOT present findings one-by-one asking for user approval. Create all todo files in parallel using the skill, then summarize results to user. </critical_instruction>
-
-**Implementation Options:**
-
-**Option A: Direct File Creation (Fast)**
-
-- Create todo files directly using Write tool
-- All findings in parallel for speed
-- Use standard template from the `todo-create` skill's [todo-template.md](../todo-create/assets/todo-template.md)
-- Follow naming convention: `{issue_id}-pending-{priority}-{description}.md`
-
-**Option B: Sub-Agents in Parallel (Recommended for Scale)** For large PRs with 15+ findings, use sub-agents to create finding files in parallel:
-
-```bash
-# Launch multiple finding-creator agents in parallel
-Task() - Create todos for first finding
-Task() - Create todos for second finding
-Task() - Create todos for third finding
-etc. for each finding.
-```
-
-Sub-agents can:
-
-- Process multiple findings simultaneously
-- Write detailed todo files with all sections filled
-- Organize findings by severity
-- Create comprehensive Proposed Solutions
-- Add acceptance criteria and work logs
-- Complete much faster than sequential processing
-
-**Execution Strategy:**
-
-1. Synthesize all findings into categories (P1/P2/P3)
-2. Group findings by severity
-3. Launch 3 parallel sub-agents (one per severity level)
-4. Each sub-agent creates its batch of todos using the todo-create skill
-5. Consolidate results and present summary
-
-**Process (Using todo-create Skill):**
-
-1. For each finding:
-
-   - Determine severity (P1/P2/P3)
-   - Write detailed Problem Statement and Findings
-   - Create 2-3 Proposed Solutions with pros/cons/effort/risk
-   - Estimate effort (Small/Medium/Large)
-   - Add acceptance criteria and work log
-
-2. Use todo-create skill for structured todo management:
-
-   ```bash
-   skill: todo-create
-   ```
-
-   The skill provides:
-
-   - Template location: the `todo-create` skill's [todo-template.md](../todo-create/assets/todo-template.md)
-   - Naming convention: `{issue_id}-{status}-{priority}-{description}.md`
-   - YAML frontmatter structure: status, priority, issue_id, tags, dependencies
-   - All required sections: Problem Statement, Findings, Solutions, etc.
-
-3. Create todo files in parallel:
-
-   ```bash
-   {next_id}-pending-{priority}-{description}.md
-   ```
-
-4. Examples:
-
-   ```
-   001-pending-p1-path-traversal-vulnerability.md
-   002-pending-p1-api-response-validation.md
-   003-pending-p2-concurrency-limit.md
-   004-pending-p3-unused-parameter.md
-   ```
-
-5. Follow template structure from todo-create skill: the `todo-create` skill's [todo-template.md](../todo-create/assets/todo-template.md)
-
-**Todo File Structure (from template):**
-
-Each todo must include:
-
-- **YAML frontmatter**: status, priority, issue_id, tags, dependencies
-- **Problem Statement**: What's broken/missing, why it matters
-- **Findings**: Discoveries from agents with evidence/location
-- **Proposed Solutions**: 2-3 options, each with pros/cons/effort/risk
-- **Recommended Action**: (Filled during triage, leave blank initially)
-- **Technical Details**: Affected files, components, database changes
-- **Acceptance Criteria**: Testable checklist items
-- **Work Log**: Dated record with actions and learnings
-- **Resources**: Links to PR, issues, documentation, similar patterns
-
-**File naming convention:**
+Collect the findings from every review agent — including code-simplicity-reviewer (section 4) and the learnings-researcher report — and dispatch a single synthesis task:
 
 ```
-{issue_id}-{status}-{priority}-{description}.md
-
-Examples:
-- 001-pending-p1-security-vulnerability.md
-- 002-pending-p2-performance-optimization.md
-- 003-pending-p3-code-cleanup.md
+Task cc-forge:review:review-synthesizer(
+  - all review-agent findings, verbatim
+  - the learnings-researcher report
+  - PR metadata and the branch-or-PR slug
+  - protected-artifacts paths
+  - cc-forge.local.md review context, if present
+  - absolute path of this repo's docs/reviews/ directory
+  - today's date
+)
 ```
 
-**Status values:**
+The synthesizer's Inputs section (`agents/review/review-synthesizer.md`) is the authoritative description of each value — pass the values, not restatements of what they mean. The synthesizer owns the synthesis rules, the review-doc template, and the filename convention (`docs/reviews/YYYY-MM-DD-NNN-<slug>-review.md`); it sanitizes the slug (lowercase, non-`[a-z0-9-]` → `-`, collapse repeats), so a branch like `feat/foo` becomes `feat-foo`. It writes the document itself and returns: the doc path, per-tier counts, the P1/P2 summary rows, the group count, and how many findings it discarded under the protected-artifacts rule. When there are zero findings it writes nothing and returns a clean-review marker (still reporting any discarded count).
 
-- `pending` - New findings, needs triage/decision
-- `ready` - Approved by manager, ready to work
-- `complete` - Work finished
+The synthesizer is always-run infrastructure — never list it in `review_agents` rosters, and it does not count toward the serial-mode agent threshold.
 
-**Priority values:**
+Before dispatching, persist each review agent's raw returned findings to one deterministic path: `docs/reviews/.raw/<sanitized-slug>/<agent>.md` (same slug sanitization the synthesizer uses). This is the fallback's source of truth — do not rely on in-context memory surviving compaction across the phases between agent dispatch and synthesis. The fallback re-derives this path from the slug, so it works even if the write happened before a compaction. `docs/reviews/.raw/` is gitignored scratch, not a review artifact.
 
-- `p1` - Critical (blocks merge, security/data issues)
-- `p2` - Important (should fix, architectural/performance)
-- `p3` - Nice-to-have (enhancements, cleanup)
+After synthesis, sanity-check the returned counts: kept + discarded + merged-duplicates should roughly equal the raw findings dispatched. A large shortfall signals the payload overflowed the synthesizer's context and findings were silently dropped — on a very large review, dispatch findings in severity-ordered batches (mirroring `--serial`) rather than one oversized call.
 
-**Tagging:** Always add `code-review` tag, plus: `security`, `performance`, `architecture`, `rails`, `quality`, etc.
+#### Step 2: Verify the Review Document
 
-#### Step 4: Summary Report
+**First, the clean-review case:** if the synthesizer returned the clean-review marker (no `Doc path` to a written file), tell the user the review found no issues and skip the rest of this step — there is no file to verify.
 
-After writing the review file and creating all todo files, present comprehensive summary:
+"Dispatch failed" means the Task call returned an error or returned without a `Doc path:` line. (A genuine hang is indistinguishable from slow synthesis in a prose-executed skill — there is no separate hang handling; rely on any session/tool-level timeout.) On failure:
+
+- **Model/spawn rejection** (the model pinned in `review-synthesizer.md` frontmatter is not on the org's allowlist): do NOT retry (a re-spawn with the same model always fails identically). Emit one line naming that pinned model and pointing at `agents/README.md` to repin, then go straight to inline fallback.
+- **Any other failure**: retry the dispatch once, then fall inline.
+
+On success, verify the doc rather than trusting the return message:
+- Confirm the returned path exists on disk.
+- Grep it for the structural anchors `/review-walk` needs: a `## Groups` heading, and at least one `### P<X>-<N>:` heading with `**Status:**` on the line below it. If missing, treat as a failed dispatch.
+- Confirm the frontmatter `target:` matches this run's branch/PR and `date:` matches today — guards against a stale same-path doc from an earlier run.
+- Re-read the verified file's `## Summary` section as the source of truth for the terminal summary.
+
+**Inline fallback:** read findings from the scratch files at `docs/reviews/.raw/<sanitized-slug>/` (not memory). Then locate the synthesizer's rules/template by trying, in order: (1) read `${CLAUDE_PLUGIN_ROOT}/agents/review/review-synthesizer.md` if that env var resolves to a non-empty path this session; (2) else `"$(git rev-parse --show-toplevel)"/agents/review/review-synthesizer.md`; (3) if neither Read succeeds, present the raw findings to the user grouped by severity rather than exiting with no output. Follow whichever resolved, and state in the terminal summary that the doc was produced by fallback, not the synthesizer.
+
+#### Step 3: Summary Report
+
+After verifying the review file, present the terminal summary:
 
 ````markdown
 ## ✅ Code Review Complete
@@ -564,87 +287,27 @@ After writing the review file and creating all todo files, present comprehensive
 **Review Target:** PR #XXXX - [PR Title] **Branch:** [branch-name]
 **Review document:** `docs/reviews/[filename]`
 
-### Findings Summary:
+### Findings
 
-- **Total Findings:** [X]
-- **🔴 CRITICAL (P1):** [count] - BLOCKS MERGE
-- **🟡 IMPORTANT (P2):** [count] - Should Fix
-- **🔵 NICE-TO-HAVE (P3):** [count] - Enhancements
+| Tier | Count | Issue | Category | Effort |
+|------|-------|-------|----------|--------|
+| P1   | [n]   | **P1-1: [Short title]** — [one-line description] | [category] | [effort] |
+|      |       | **P1-2: [Short title]** — [one-line description] | [category] | [effort] |
+| P2   | [n]   | **P2-1: [Short title]** — [one-line description] | [category] | [effort] |
+| P3   | [n]   | _[n] nice-to-haves: [one-line roll-up of themes] (full detail in the review doc)_ | — | — |
 
-### Created Todo Files:
+Every P1 and P2 gets its own row (copy the rows from the review doc's Summary); P3s are one roll-up row. Counts appear once per tier.
 
-**P1 - Critical (BLOCKS MERGE):**
+### Review Agents Used
 
-- `001-pending-p1-{finding}.md` - {description}
-- `002-pending-p1-{finding}.md` - {description}
+- [list only the agents that returned findings this run]
+- [if any dispatched agent failed or returned nothing, name it here: "Did not complete: <agent> — coverage for its area is missing"]
+- review-synthesizer (synthesis + document)
 
-**P2 - Important:**
+### Next Steps
 
-- `003-pending-p2-{finding}.md` - {description}
-- `004-pending-p2-{finding}.md` - {description}
-
-**P3 - Nice-to-Have:**
-
-- `005-pending-p3-{finding}.md` - {description}
-
-### Review Agents Used:
-
-- security-sentinel-python / security-sentinel-typescript
-- performance-oracle-python / performance-oracle-typescript
-- architecture-strategist
-- correctness-auditor
-- reliability-engineer
-- test-coverage-reviewer
-- adversarial-reviewer (if applicable)
-- [other agents]
-
-### Next Steps:
-
-1. **Address P1 Findings**: CRITICAL - must be fixed before merge
-
-   - Review each P1 todo in detail
-   - Implement fixes or request exemption
-   - Verify fixes before merging PR
-
-2. **Triage All Todos**:
-   ```bash
-   ls .context/cc-forge/todos/*-pending-*.md todos/*-pending-*.md 2>/dev/null  # View all pending todos
-   /todo-triage             # Use slash command for interactive triage
-   ```
-
-3. **Work on Approved Todos**:
-
-   ```bash
-   /todo-resolve  # Fix all approved items efficiently
-   ```
-
-4. **Track Progress**:
-   - Rename file when status changes: pending → ready → complete
-   - Update Work Log as you work
-   - Commit review findings and status updates
-
-### Severity Breakdown:
-
-**🔴 P1 (Critical - Blocks Merge):**
-
-- Security vulnerabilities
-- Data corruption risks
-- Breaking changes
-- Critical architectural issues
-
-**🟡 P2 (Important - Should Fix):**
-
-- Performance issues
-- Significant architectural concerns
-- Major code quality problems
-- Reliability issues
-
-**🔵 P3 (Nice-to-Have):**
-
-- Minor improvements
-- Code cleanup
-- Optimization opportunities
-- Documentation updates
+1. **Address P1 findings** — critical; must be fixed before merge.
+2. **Walk the review** — run `/review-walk docs/reviews/[filename]` to step through issues group-by-group with implement / defer / skip choices. Status updates land in the review doc, so progress is durable.
 ````
 
 ### 6. End-to-End Testing (Optional)
@@ -695,7 +358,7 @@ After presenting the Summary Report, offer appropriate testing based on project 
 Spawn a subagent to run browser tests (preserves main context):
 
 ```
-Task general-purpose("Run /test-browser for PR #[number]. Test all affected pages, check for console errors, handle failures by creating todos and fixing.")
+Task general-purpose("Run /test-browser for PR #[number]. Test all affected pages, check for console errors, report failures as P1 findings and fix.")
 ```
 
 The subagent will:
@@ -704,7 +367,7 @@ The subagent will:
 3. Check for console errors
 4. Test critical interactions
 5. Pause for human verification on OAuth/email/payment flows
-6. Create P1 todos for any failures
+6. Report any failures as P1 findings
 7. Fix and retry until all tests pass
 
 **Standalone:** `/test-browser [PR number]`
@@ -725,7 +388,7 @@ The subagent will:
 5. Take screenshots of key screens
 6. Capture console logs for errors
 7. Pause for human verification (Sign in with Apple, push, IAP)
-8. Create P1 todos for any failures
+8. Report any failures as P1 findings
 9. Fix and retry until all tests pass
 
 **Standalone:** `/xcode-test [scheme]`


### PR DESCRIPTION
### Primary Changes
- 📌 **Pin review models:** all 14 agents/review/*.md now run claude-sonnet-5 (was inherit); review-synthesizer runs claude-opus-4-8. Applies to every caller (deep-review, compound, deepen-plan).
- 🧩 **Dedicated synthesizer:** new agents/review/review-synthesizer.md owns findings synthesis + writes the review doc (dedupe, severity/category/confidence/grouping, template). Replaces inline synthesis in deep-review §5, guaranteeing opus-quality synthesis in a fresh context.
- 📊 **Tier-table summary:** every P1/P2 as its own row, P3s rolled up, per-tier count column — in both review doc and terminal summary.
- 🧹 **Dead-code removal:** deleted the phantom todo-creation step (nonexistent todo-create skill) and /todo-triage//todo-resolve next-steps; point at /review-walk.
- 🛡️ **Hardening:** slug sanitization, path-based protected-artifacts gate (crosses nested dirs), create-only write, verify-on-disk with fallback, escape rule for structural text in field values.
- 📝 **Docs:** agents/README.md + agents/CLAUDE.md synced (new row, model-pin notes, review/ count 14→15).

---

### Test Plan

**Pre-merge Tests**
- [x] grep: zero \`model: inherit\` under agents/review/; all 14 pin sonnet-5, synthesizer pins opus-4-8
- [x] grep: zero todo-create/todo-triage/todo-resolve refs in deep-review SKILL.md
- [x] /review-walk parse anchors present verbatim in synthesizer template
- [x] two live /deep-review passes on this branch: doc written, sequence auto-incremented 001→002, verify + tier table confirmed

**Post-merge Tests**
- [ ] Plugin-cache clear + reinstall; confirm review-synthesizer appears in /agents
- [ ] Live /deep-review on an unrelated repo, then /review-walk the produced doc
- [ ] Zero-findings run (clean-review, no doc written) and protected-artifacts discard path

Generated with [Claude Code](https://claude.com/claude-code)