### PR TITLE
feat(agents): rule-of-three threshold for duplication detection

### DIFF
--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -12,5 +12,6 @@ Overlapping reviewers (reliability, data-integrity, adversarial) carry explicit 
 
 ## Related
 
+- **PR #51** (2026-07-13): add the rule of three to pattern-recognition-specialist — duplication is flagged for extraction only at the third occurrence, reconciling its prior second-copy bias with the reviewers' "simple duplication beats DRY" — [plan](docs/plans/2026-07-13-001-feat-rule-of-three-pattern-agent-plan.md)
 - **PR #50** (2026-07-09): pin all 14 review agents to claude-sonnet-5 and extract /deep-review synthesis into a dedicated review-synthesizer agent (claude-opus-4-8) that writes the review doc; tier-table summary, dead todo-step removed — [plan](docs/plans/2026-07-09-001-feat-review-model-pins-synthesizer-plan.md)
 - **PR #42** (2026-06-24): overhaul review agents — 5 new specialists, security/perf split into python+ts, de-Rails'd, phantom refs removed — closes #41

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -39,7 +39,7 @@ Your primary responsibilities:
    - Constants and configuration values
    Identify deviations from established conventions and suggest improvements.
 
-4. **Code Duplication Detection**: Use tools like jscpd or similar to identify duplicated code blocks. Set appropriate thresholds (e.g., --min-tokens 50) based on the language and context. Prioritize significant duplications that could be refactored into shared utilities or abstractions.
+4. **Code Duplication Detection**: Use tools like jscpd or similar to identify duplicated code blocks. Set appropriate thresholds (e.g., --min-tokens 50) based on the language and context. Apply the **rule of three**: two similar instances are not a finding — flag for extraction only at the **third** occurrence, where the maintenance cost of the duplication outweighs the risk of committing to a premature, wrong abstraction. Two copies may be a deliberate choice; do not recommend a shared utility until a stable pattern is visible across three uses. Prioritize third-and-beyond duplications that could be refactored into shared utilities or abstractions.
 
 5. **Architectural Boundary Review**: Analyze layer violations and architectural boundaries:
    - Check for proper separation of concerns


### PR DESCRIPTION
### Primary Changes
- 📏 **Rule of three:** pattern-recognition-specialist §4 (duplication detection) now flags code for extraction only at the *third* occurrence — two similar instances are no longer a finding. Rationale stated: maintenance cost vs. the risk of a premature wrong abstraction.
- 🤝 **Reconciles a live contradiction:** the agent previously biased toward flagging second copies, contradicting python-reviewer/typescript-reviewer's "simple duplication beats DRY." The threshold makes the two stances agree — 2 copies leave, 3 extract.
- 🏠 **Single home:** rule lives in this one agent only (no new agent, no copies into other reviewers) — avoids the cross-agent duplicate-findings problem PR #42 flagged.

### Related Issue
N/A

---

### Test Plan

**Pre-merge Tests**
- [x] grep: rule-of-three text present in pattern-recognition-specialist §4
- [x] grep: exactly one agent carries the rule (reviewers untouched)

**Post-merge Tests**
- [ ] Plugin-cache clear + reinstall; run /deep-review on a diff with a 2nd vs 3rd duplication and confirm only the 3rd is flagged

Generated with [Claude Code](https://claude.com/claude-code)