### PR TITLE
docs: fix deep-review .raw cleanup + plugin-reload guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ When referencing agents from within SKILL.md files, use fully-qualified names:
 
 ## Related
 
+- **PR #52** (2026-07-13): /deep-review deletes docs/reviews/.raw/<slug>/ after the synthesized doc is verified (never on fallback/clean-review); fixed README + CLAUDE.md plugin-reload guidance — /plugin update no-ops on an unchanged version, so use uninstall + rm -rf cache + install + restart
 - **PR #49** (2026-07-09): add /compact-prep — interactive skill that gathers git+session state, asks the next session's focus, writes a fresh-agent handoff doc to docs/handoff/, and prints the @-ref to paste after /compact; also gitignore docs/reviews/ — [plan](docs/plans/2026-07-07-001-feat-compact-prep-skill-plan.md)
 - **PR #43** (2026-06-25): remove document-review skill (broken agent refs, stale names), document plugin cache staleness workaround in README — [session](https://claude.ai/code/session_017p7uuzAi5nJw7s4usffXyD)
 - **PR #39** (2026-06-23): /land now verifies CI and merges — after stamping CLAUDE.md it runs local tests, watches Actions, fixes failures with confirmed re-commits (max 3), squash-merges, and syncs main — [plan](docs/plans/2026-06-23-001-feat-land-merge-flow-plan.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ cp -r skills/<name> ~/.claude/skills/
 cp -r agents/<category> ~/.claude/agents/
 ```
 
-Editing a file in this repo does **not** make it live — apply it by re-running the plugin install or copying the changed folder into `~/.claude/`.
+Editing a file in this repo does **not** make it live — the plugin loads from a cache copy, read once at session start. `/plugin update` does **not** apply changes: it keys off the `version` in `.claude-plugin/plugin.json` and no-ops when that's unchanged, so newly added agents/skills never appear (you'll see `Agent type '…' not found`). To apply any change, force a clean reinstall then restart Claude Code: `/plugin uninstall cc-forge && rm -rf ~/.claude/plugins/cache/cc-forge-local/ && /plugin install cc-forge` (or copy the changed folder into `~/.claude/` for the cherry-pick route). See the README "Applying repo changes" note.
 
 The `/caveman` hook is wired automatically by the plugin path via `hooks/hooks.json`. Only the cherry-pick route needs the manual `settings.json` paste documented in the README ("Caveman hook setup"). When adding a new hook in the future, add its script to `hooks/` and declare it in `hooks/hooks.json` (using `${CLAUDE_PLUGIN_ROOT}` for the path) so plugin installs pick it up automatically.
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,17 @@ This installs **all skills, all agents, and the caveman hook** — the hook is w
 
 (The marketplace is named `cc-forge-local` with `source: "./"`, so add it by the **path to your clone**, not a remote `owner/repo` reference.)
 
-> **Reinstalling after renamed or deleted files?** The plugin cache overlays new files but doesn't prune removed ones. If a reinstall picks up stale agents or skills, clear the cache first:
+> **Applying repo changes to the installed plugin.** Editing files in this clone does **not** make them live — the plugin loads from a cache copy under `~/.claude/plugins/cache/`, and agents/skills are read once at session start. `/plugin update` does **not** help for a local directory-source plugin: it compares the `version` string in `.claude-plugin/plugin.json`, so if that hasn't bumped it reports "already at the latest version" and rebuilds nothing — even when new commits added agents or skills. That's why a newly added agent shows up as `Agent type '…' not found`.
+>
+> To pick up any repo change (added, renamed, or deleted files), force a clean reinstall, then **restart Claude Code** so the new agents/skills load:
 >
 > ```bash
+> /plugin uninstall cc-forge
 > rm -rf ~/.claude/plugins/cache/cc-forge-local/
 > /plugin install cc-forge
 > ```
+>
+> A reinstall alone can leave stale metadata pointing at an already-deleted cache dir; the `rm -rf` guarantees the cache rebuilds from your clone's current `HEAD` (uncommitted working-tree edits included).
 
 ### Cherry-pick individual pieces
 

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -274,6 +274,7 @@ On success, verify the doc rather than trusting the return message:
 - Grep it for the structural anchors `/review-walk` needs: a `## Groups` heading, and at least one `### P<X>-<N>:` heading with `**Status:**` on the line below it. If missing, treat as a failed dispatch.
 - Confirm the frontmatter `target:` matches this run's branch/PR and `date:` matches today — guards against a stale same-path doc from an earlier run.
 - Re-read the verified file's `## Summary` section as the source of truth for the terminal summary.
+- Once the doc passes every check above, delete this run's scratch: `rm -rf docs/reviews/.raw/<sanitized-slug>/`. Only after a verified write — never on the fallback path, which reads from it. The clean-review case keeps its scratch (there is no verified doc to gate on).
 
 **Inline fallback:** read findings from the scratch files at `docs/reviews/.raw/<sanitized-slug>/` (not memory). Then locate the synthesizer's rules/template by trying, in order: (1) read `${CLAUDE_PLUGIN_ROOT}/agents/review/review-synthesizer.md` if that env var resolves to a non-empty path this session; (2) else `"$(git rev-parse --show-toplevel)"/agents/review/review-synthesizer.md`; (3) if neither Read succeeds, present the raw findings to the user grouped by severity rather than exiting with no output. Follow whichever resolved, and state in the terminal summary that the doc was produced by fallback, not the synthesizer.
 


### PR DESCRIPTION
### Primary Changes
- 🧹 **Delete .raw scratch after verified write:** /deep-review now runs `rm -rf docs/reviews/.raw/<slug>/` once the synthesized doc passes its existence + anchor + frontmatter checks — never on the fallback path (which reads that scratch) and never in the clean-review case.
- 📝 **Correct plugin-reload guidance:** `/plugin update` no-ops on an unchanged version string, so repo changes never reach the cache. README note + root CLAUDE.md now document the uninstall + `rm -rf` cache + install + restart sequence, and explain the `Agent type '…' not found` symptom.

---

### Test Plan

**Pre-merge Tests**
- [ ] none — docs + skill-prose only, no runnable code

**Post-merge Tests**
- [ ] Reinstall the plugin, run /deep-review, confirm the doc is written and docs/reviews/.raw/<slug>/ is gone afterward

Generated with [Claude Code](https://claude.com/claude-code)