### PR TITLE
fix(skills): branch-from-issue prints /rename instead of running it; work summary links use absolute paths

### DIFF
--- a/skills/branch-from-issue/SKILL.md
+++ b/skills/branch-from-issue/SKILL.md
@@ -73,8 +73,8 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
 
 9. **Create and checkout:** `git checkout -b {branch-name}`
 
-10. **Rename the session** to match the branch name using the `/rename` built-in command:
-    - Invoke `/rename {branch-name}` so the session is identifiable when resuming later.
+10. **Output the branch name as the `/rename` command.** `/rename` only works when the user invokes it manually — do not run it. Print the full command using the branch name:
+    > `/rename {branch-name}`
 
 11. **Post a comment on the GitHub issue** (only if an issue number was provided):
     ```bash

--- a/skills/work/CLAUDE.md
+++ b/skills/work/CLAUDE.md
@@ -1,4 +1,5 @@
 # Work
 
 ## Related
+- **PR #53** (2026-07-14): /work end-of-work summary table now links files by absolute filesystem path instead of repo-relative, so links actually open in the editor; /branch-from-issue also fixed to print the /rename command instead of invoking it
 - **PR #46** (2026-06-30): overhaul /work skill — drop dead refs (Figma, worktree, agent-browser, setup skill, AGENTS.md), add end-of-work summary table, trim attribution boilerplate, add Swarm cost warning — closes #45

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -228,14 +228,14 @@ This command takes a work document (plan, specification, or todo file) and execu
 
 2. **Display Work Summary**
 
-   Run `git diff --stat` (against the branch point or last commit before `/work` started) and present a summary table:
+   Run `git diff --stat` (against the branch point or last commit before `/work` started) and present a summary table. Resolve each file's absolute path with `git rev-parse --show-toplevel` + the relative path so the link actually opens — a repo-relative path alone won't resolve in the user's editor:
 
    | File | +/- | Unit | Tests | Summary |
    |------|-----|------|-------|---------|
-   | [`path/to/file.ts`](path/to/file.ts) | +45 / -12 | Auth middleware | pass | Added token refresh logic |
+   | [`path/to/file.ts`](/absolute/path/to/repo/path/to/file.ts) | +45 / -12 | Auth middleware | pass | Added token refresh logic |
 
    **Column definitions:**
-   - **File** — relative path, hyperlinked to open in the user's editor
+   - **File** — relative path as link text, but the link target must be the absolute filesystem path
    - **+/-** — insertions and deletions for that file
    - **Unit** — which plan implementation unit the change maps to (or "—" if not from a plan)
    - **Tests** — pass / fail / no tests (whether tests covering this file were run and their result)


### PR DESCRIPTION
### Primary Changes
- 🔧 **branch-from-issue:** step 10 now outputs the `/rename {branch-name}` command as text instead of invoking `/rename` directly (which only works on manual user invocation)
- 🔗 **work:** end-of-work summary table now links each file using its absolute filesystem path (via `git rev-parse --show-toplevel`) instead of a repo-relative path, so links actually open in the editor

---

### Test Plan

**Pre-merge Tests**
- [ ] Manually invoke /branch-from-issue and /work on a test plan to confirm the doc changes read correctly

**Post-merge Tests**
- [ ] None

Generated with [Claude Code](https://claude.com/claude-code)