### PR TITLE
feat: standardized issue-log stamps across workflow skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-forge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A streamlined Claude Code plugin for structured development workflows, code review, and research automation.",
   "author": {
     "name": "Hagen Fritz"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/ideate` - Generate improvement ideas
 - `/deepen-plan` - Enhance plans with research
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
-- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs. At walk end, offers batch tracking issues for deferred items and stamps the walk outcome on the linked issue.
+- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs. Stamps the walk outcome on the linked issue at the end.
 - `/caveman` - Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook that re-injects a reminder when active. Off by default. Activate with `/caveman <level>`; deactivate with `/caveman off`, "stop caveman", or "normal mode".
 
 **Strategic:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/ideate` - Generate improvement ideas
 - `/deepen-plan` - Enhance plans with research
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
-- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs. Stamps the walk outcome on the linked issue at the end.
+- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs. At walk end, offers tracking issues for deferred items (using issue-from-context's template) and stamps the walk outcome on the linked issue.
 - `/caveman` - Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook that re-injects a reminder when active. Off by default. Activate with `/caveman <level>`; deactivate with `/caveman off`, "stop caveman", or "normal mode".
 
 **Strategic:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ docs/             Plans, brainstorms, reviews, initiatives generated at runtime
 
 Core workflow: brainstorm -> plan -> work -> review -> compound
 
+**Issue-log convention:** the workflow skills stamp their key events onto the linked GitHub issue as standardized comments (hidden `<!-- cc-forge-log v1: {...} -->` marker + short human body), making the issue thread a reconstructable work log. All shared rules — envelope, event registry, issue-number resolution, encoding, failure posture, reader contract — live in `skills/issue-log/SKILL.md` (a non-invocable reference skill). Writer skills embed only their own filled stamp template and reference the spec; never restate a shared rule inline.
+
 - `/brainstorm` - Explore requirements and approaches
 - `/plan` - Create implementation plans
 - `/work` - Execute work plans
@@ -32,7 +34,7 @@ Core workflow: brainstorm -> plan -> work -> review -> compound
 - `/ideate` - Generate improvement ideas
 - `/deepen-plan` - Enhance plans with research
 - `/deprecate` - Plan-only safe removal of a named concept (parallel research agents, leaves-first plan, compat-risk flags; hand off to `/work`)
-- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs.
+- `/review-walk` - Guided execution of a `/deep-review` document. Walks issues group-by-group with a plain-English teach moment per group, then per-issue **implement / defer / skip / explain more**. Updates `Status:` inline in the review doc — durable, resumable. Auto-discovers the latest `docs/reviews/*.md` if no path is given. Falls back to issue-by-issue order on pre-enrichment review docs. At walk end, offers batch tracking issues for deferred items and stamps the walk outcome on the linked issue.
 - `/caveman` - Ultra-terse response mode (lite/full/ultra). Persists across turns via a `UserPromptSubmit` hook that re-injects a reminder when active. Off by default. Activate with `/caveman <level>`; deactivate with `/caveman off`, "stop caveman", or "normal mode".
 
 **Strategic:**

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Restart Claude Code after copying. Skills become available as `/<name>` slash co
 | `/deepen-plan` | Stress-tests an existing plan and selectively strengthens weak sections with targeted research | A Standard/Deep or high-risk plan needs more confidence around decisions, sequencing, or risk |
 | `/work` | Executes a work plan unit-by-unit, following repo patterns and testing as it goes | You have a plan and want it implemented |
 | `/deep-review` | Exhaustive multi-agent code review using worktrees; writes a structured review doc | Complex, risky, or large changes that warrant deep review |
-| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable; stamps the walk outcome at the end | You have a `docs/reviews/*.md` and want to act on it methodically |
+| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable; at walk end, offers tracking issues for deferred items (shared issue template) and stamps the outcome | You have a `docs/reviews/*.md` and want to act on it methodically |
 | `/compound` | Documents a recently solved problem so the knowledge compounds | Right after solving something non-obvious worth recording |
 | `/ideate` | Generates and critically evaluates grounded improvement ideas for the project | "What should I improve?" — you want AI-generated directions before brainstorming one |
 | `/deprecate` | Plan-only safe removal of a named concept: parallel research agents find every reference, output a leaves-first plan with compat-risk flags | "Rip out X" / "retire X" — hand the resulting plan to `/work` |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Restart Claude Code after copying. Skills become available as `/<name>` slash co
 | `/deepen-plan` | Stress-tests an existing plan and selectively strengthens weak sections with targeted research | A Standard/Deep or high-risk plan needs more confidence around decisions, sequencing, or risk |
 | `/work` | Executes a work plan unit-by-unit, following repo patterns and testing as it goes | You have a plan and want it implemented |
 | `/deep-review` | Exhaustive multi-agent code review using worktrees; writes a structured review doc | Complex, risky, or large changes that warrant deep review |
-| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable; at walk end, offers tracking issues for deferred items and stamps the outcome | You have a `docs/reviews/*.md` and want to act on it methodically |
+| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable; stamps the walk outcome at the end | You have a `docs/reviews/*.md` and want to act on it methodically |
 | `/compound` | Documents a recently solved problem so the knowledge compounds | Right after solving something non-obvious worth recording |
 | `/ideate` | Generates and critically evaluates grounded improvement ideas for the project | "What should I improve?" — you want AI-generated directions before brainstorming one |
 | `/deprecate` | Plan-only safe removal of a named concept: parallel research agents find every reference, output a leaves-first plan with compat-risk flags | "Rip out X" / "retire X" — hand the resulting plan to `/work` |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Restart Claude Code after copying. Skills become available as `/<name>` slash co
 
 ## Skills
 
+**Issue-log convention:** the workflow skills (brainstorm, plan, work, deep-review, review-walk, ship, land, tree, branch-from-issue, side-quest) each post a standardized "stamp" comment to the linked GitHub issue at their key event — a hidden machine-readable marker plus a short human-readable body — so an issue's thread becomes a reconstructable work log. The spec lives at [`skills/issue-log/SKILL.md`](skills/issue-log/SKILL.md) (a reference doc, not a command).
+
 ### Core workflow
 
 | Skill | What it does | When to use |
@@ -57,7 +59,7 @@ Restart Claude Code after copying. Skills become available as `/<name>` slash co
 | `/deepen-plan` | Stress-tests an existing plan and selectively strengthens weak sections with targeted research | A Standard/Deep or high-risk plan needs more confidence around decisions, sequencing, or risk |
 | `/work` | Executes a work plan unit-by-unit, following repo patterns and testing as it goes | You have a plan and want it implemented |
 | `/deep-review` | Exhaustive multi-agent code review using worktrees; writes a structured review doc | Complex, risky, or large changes that warrant deep review |
-| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable | You have a `docs/reviews/*.md` and want to act on it methodically |
+| `/review-walk` | Walks a `/deep-review` document interactively, group-by-group, with implement/defer/skip per issue; updates `Status:` inline so it's resumable; at walk end, offers tracking issues for deferred items and stamps the outcome | You have a `docs/reviews/*.md` and want to act on it methodically |
 | `/compound` | Documents a recently solved problem so the knowledge compounds | Right after solving something non-obvious worth recording |
 | `/ideate` | Generates and critically evaluates grounded improvement ideas for the project | "What should I improve?" — you want AI-generated directions before brainstorming one |
 | `/deprecate` | Plan-only safe removal of a named concept: parallel research agents find every reference, output a leaves-first plan with compat-risk flags | "Rip out X" / "retire X" — hand the resulting plan to `/work` |
@@ -96,7 +98,7 @@ Typical flow: `/initiative` → `/plan` per workstream → `/work` → `/initiat
 
 | Skill | What it does | When to use |
 |---|---|---|
-| `/side-quest` | Documents out-of-scope tasks or tech debt discovered during execution and ties them to the current issue | You hit something worth tracking but out of scope for the current task |
+| `/side-quest` | Documents out-of-scope tasks or tech debt discovered during execution, files a `follow-up`-labeled tracking issue, and stamps the originating issue | You hit something worth tracking but out of scope for the current task |
 | `/stand-up` | Summarizes the past 28h of commits, PRs, and linked issues | A daily catch-up on what moved |
 | `/test-plan` | Generates a manual test plan from current branch diffs (unstaged, staged, committed); saves a living doc to `docs/tests/` with pass/fail you update | You want a structured manual-testing pass over a branch's changes |
 

--- a/scripts/sync-workflows.sh
+++ b/scripts/sync-workflows.sh
@@ -6,6 +6,11 @@ rm -f .devin/workflows/*.md
 
 for skill_file in skills/*/SKILL.md; do
   skill=$(basename $(dirname "$skill_file"))
+  # Reference-only skills (never invoked) get no Devin workflow
+  if grep -q "^user-invocable: false" "$skill_file"; then
+    echo "Skipped ${skill} (user-invocable: false)"
+    continue
+  fi
   # Extract description, remove quotes if present
   desc=$(grep -m 1 "^description:" "$skill_file" | sed 's/^description: *//' | sed 's/^"//;s/"$//' | sed "s/^'//;s/'$//")
   

--- a/scripts/sync-workflows.sh
+++ b/scripts/sync-workflows.sh
@@ -7,7 +7,7 @@ rm -f .devin/workflows/*.md
 for skill_file in skills/*/SKILL.md; do
   skill=$(basename $(dirname "$skill_file"))
   # Reference-only skills (never invoked) get no Devin workflow
-  if grep -q "^user-invocable: false" "$skill_file"; then
+  if grep -qE '^user-invocable:[[:space:]]*"?false"?[[:space:]]*(#.*)?$' "$skill_file"; then
     echo "Skipped ${skill} (user-invocable: false)"
     continue
   fi

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -1,6 +1,6 @@
 # Skills
 
-Slash-command skills for Claude Code. Each subdirectory is one skill with a `SKILL.md` (YAML frontmatter — `name`, `description`, `argument-hint`, `allowed-tools` — followed by the workflow prose). Claude Code loads these from `~/.claude/skills/`; editing a file here goes live only after re-running the plugin install or copying the folder into `~/.claude/`.
+Slash-command skills for Claude Code. Each subdirectory is one skill with a `SKILL.md` (YAML frontmatter — `name`, `description`, `argument-hint`, `allowed-tools`, plus `user-invocable: false` + `disable-model-invocation: true` for reference-only skills — followed by the workflow prose). Claude Code loads these from `~/.claude/skills/`; editing a file here goes live only after re-running the plugin install or copying the folder into `~/.claude/`.
 
 A pre-commit hook runs `scripts/sync-workflows.sh`, which regenerates `.devin/workflows/*.md` (gitignored) from every `SKILL.md` here — except reference-only skills (`user-invocable: false`), which are skipped.
 
@@ -8,5 +8,6 @@ A pre-commit hook runs `scripts/sync-workflows.sh`, which regenerates `.devin/wo
 
 ## Related
 
+- **PR #59** (2026-07-21): issue-log stamp convention — new skills/issue-log reference spec (marker v1, event registry, reader contract) + ten skills stamp their key events onto the linked issue; posting hardened to --body-file after deep-review — [plan](docs/plans/2026-07-21-001-feat-issue-log-standard-plan.md)
 - **PR #55** (2026-07-15): add /tree, /preview, /unpreview for a git-worktree dev workflow (primary checkout stays on main; feature work in sibling worktrees), and fix /ship + /land to operate correctly from inside a worktree
 - **PR #40** (2026-06-23): /land now reconciles CLAUDE.md body prose with the merged diff (not just appends); /ship splits Test Plan into Pre-merge/Post-merge; added scripts/sync-workflows.sh

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -2,7 +2,9 @@
 
 Slash-command skills for Claude Code. Each subdirectory is one skill with a `SKILL.md` (YAML frontmatter — `name`, `description`, `argument-hint`, `allowed-tools` — followed by the workflow prose). Claude Code loads these from `~/.claude/skills/`; editing a file here goes live only after re-running the plugin install or copying the folder into `~/.claude/`.
 
-A pre-commit hook runs `scripts/sync-workflows.sh`, which regenerates `.devin/workflows/*.md` (gitignored) from every `SKILL.md` here.
+A pre-commit hook runs `scripts/sync-workflows.sh`, which regenerates `.devin/workflows/*.md` (gitignored) from every `SKILL.md` here — except reference-only skills (`user-invocable: false`), which are skipped.
+
+`issue-log/` is one such reference skill: it holds the issue-log stamp spec (envelope, event registry, shared rules) that the workflow skills' stamp blocks link to. When touching any stamp block, change shared rules only in the spec.
 
 ## Related
 

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -307,10 +307,9 @@ Planning is blocked by:
 Resume with `/brainstorm` when ready to resolve these before planning.
 ```
 
-After displaying either summary, if a requirements document was written and a GitHub issue is already known in this session, post an issue-log stamp on it — envelope, posting, and skip/failure rules per [the issue-log spec](../issue-log/SKILL.md); otherwise skip silently (the common case, since brainstorms usually precede the issue).
+After displaying either summary, if a requirements document was written and an issue is resolvable per [the issue-log spec](../issue-log/SKILL.md)'s resolution precedence, post an issue-log stamp on it — envelope, posting, and skip/failure rules are the spec's; otherwise skip silently (the common case, since brainstorms usually precede the issue). Compose the body below, write it to a temp file with the Write tool, and post:
 
-```bash
-gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
+```markdown
 <!-- cc-forge-log v1: {"skill":"brainstorm","event":"requirements-written","paths":["docs/brainstorms/<requirements-filename>"]} -->
 
 ### 🧠 /brainstorm — <topic title>
@@ -319,6 +318,7 @@ gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
 **Requirements:**
 - R1. <requirement — port every requirement from the doc's Requirements section verbatim, not a selection>
 - R2. <…>
-EOF
-)"
+```
+```bash
+gh issue comment <issue-number> --repo <owner>/<repo> --body-file <temp-file>
 ```

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -306,3 +306,19 @@ Planning is blocked by:
 
 Resume with `/brainstorm` when ready to resolve these before planning.
 ```
+
+After displaying either summary, if a requirements document was written and a GitHub issue is already known in this session, post an issue-log stamp on it — envelope, posting, and skip/failure rules per [the issue-log spec](../issue-log/SKILL.md); otherwise skip silently (the common case, since brainstorms usually precede the issue).
+
+```bash
+gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
+<!-- cc-forge-log v1: {"skill":"brainstorm","event":"requirements-written","paths":["docs/brainstorms/<requirements-filename>"]} -->
+
+### 💡 /brainstorm — <topic title>
+
+**Doc:** `docs/brainstorms/<requirements-filename>`
+**Key decisions:**
+- <key decision, 2-4 bullets>
+**Unresolved:** <outstanding questions as one-liners, or "none">
+EOF
+)"
+```

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -313,12 +313,12 @@ After displaying either summary, if a requirements document was written and a Gi
 gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
 <!-- cc-forge-log v1: {"skill":"brainstorm","event":"requirements-written","paths":["docs/brainstorms/<requirements-filename>"]} -->
 
-### 💡 /brainstorm — <topic title>
+### 🧠 /brainstorm — <topic title>
 
 **Doc:** `docs/brainstorms/<requirements-filename>`
-**Key decisions:**
-- <key decision, 2-4 bullets>
-**Unresolved:** <outstanding questions as one-liners, or "none">
+**Requirements:**
+- R1. <requirement — port every requirement from the doc's Requirements section verbatim, not a selection>
+- R2. <…>
 EOF
 )"
 ```

--- a/skills/branch-from-issue/SKILL.md
+++ b/skills/branch-from-issue/SKILL.md
@@ -76,16 +76,16 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
 10. **Output the branch name as the `/rename` command.** `/rename` only works when the user invokes it manually — do not run it. Print the full command using the branch name:
     > `/rename {branch-name}`
 
-11. **Post an issue-log stamp on the GitHub issue** (only if an issue number was provided). Post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
-    ```bash
-    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "$(cat <<'EOF'
+11. **Post an issue-log stamp on the GitHub issue** (only if an issue number was provided). Compose the body below, write it to a temp file with the Write tool, and post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
+    ```markdown
     <!-- cc-forge-log v1: {"skill":"branch-from-issue","event":"branch-created"} -->
 
     ### 🌱 /branch-from-issue — branch created
 
     **Branch:** `{branch-name}`
-    EOF
-    )"
+    ```
+    ```bash
+    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body-file <temp-file>
     ```
 
 12. Output the new branch name.

--- a/skills/branch-from-issue/SKILL.md
+++ b/skills/branch-from-issue/SKILL.md
@@ -76,9 +76,16 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
 10. **Output the branch name as the `/rename` command.** `/rename` only works when the user invokes it manually — do not run it. Print the full command using the branch name:
     > `/rename {branch-name}`
 
-11. **Post a comment on the GitHub issue** (only if an issue number was provided):
+11. **Post an issue-log stamp on the GitHub issue** (only if an issue number was provided). Post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
     ```bash
-    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "Branch created: \`{branch-name}\`"
+    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "$(cat <<'EOF'
+    <!-- cc-forge-log v1: {"skill":"branch-from-issue","event":"branch-created"} -->
+
+    ### 🌱 /branch-from-issue — branch created
+
+    **Branch:** `{branch-name}`
+    EOF
+    )"
     ```
 
 12. Output the new branch name.

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -286,6 +286,7 @@ gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 
 ### 🔍 /deep-review — review written
 
+**Doc:** `docs/reviews/<filename>`
 **Findings:** <n> P1 / <n> P2 / <n> P3
 
 | Tier | Count | Issue | Category | Effort |

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -286,15 +286,18 @@ gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 
 ### 🔍 /deep-review — review written
 
-**Doc:** `docs/reviews/<filename>`
 **Findings:** <n> P1 / <n> P2 / <n> P3
-**Top findings:**
-- <P1-1: one-line description>
-- <next finding: one-line description>
-- <third finding: one-line description, only when it carries signal>
+
+| Tier | Count | Issue | Category | Effort |
+|------|-------|-------|----------|--------|
+| P1   | <n>   | **P1-1: <short title>** — <one-line description> | <category> | <effort> |
+| P2   | <n>   | **P2-1: <short title>** — <one-line description> | <category> | <effort> |
+| P3   | <n>   | _<n> nice-to-haves: <one-line roll-up of themes> (full detail in the review doc)_ | — | — |
 EOF
 )"
 ```
+
+The table is the same one Step 3's terminal summary builds: every P1 and P2 gets its own row (copy them from the review doc's Summary), P3s are one roll-up row — nothing else in the body.
 
 #### Step 3: Summary Report
 

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -278,6 +278,24 @@ On success, verify the doc rather than trusting the return message:
 
 **Inline fallback:** read findings from the scratch files at `docs/reviews/.raw/<sanitized-slug>/` (not memory). Then locate the synthesizer's rules/template by trying, in order: (1) read `${CLAUDE_PLUGIN_ROOT}/agents/review/review-synthesizer.md` if that env var resolves to a non-empty path this session; (2) else `"$(git rev-parse --show-toplevel)"/agents/review/review-synthesizer.md`; (3) if neither Read succeeds, present the raw findings to the user grouped by severity rather than exiting with no output. Follow whichever resolved, and state in the terminal summary that the doc was produced by fallback, not the synthesizer.
 
+**Stamp the linked issue:** once the doc has passed every verification check above (the same gate that deleted the scratch), post a stamp on the issue this review's branch/PR is tied to. The clean-review case posts no stamp — there is no doc to reference. A fallback-produced doc never passes this gate, so it posts none either. Issue-number resolution (including the skip when none resolves), posting mechanics, marker encoding, and failure handling are defined in [the issue-log spec](../issue-log/SKILL.md).
+
+```bash
+gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
+<!-- cc-forge-log v1: {"skill":"deep-review","event":"review-written","paths":["docs/reviews/<filename>"]} -->
+
+### 🔍 /deep-review — review written
+
+**Doc:** `docs/reviews/<filename>`
+**Findings:** <n> P1 / <n> P2 / <n> P3
+**Top findings:**
+- <P1-1: one-line description>
+- <next finding: one-line description>
+- <third finding: one-line description, only when it carries signal>
+EOF
+)"
+```
+
 #### Step 3: Summary Report
 
 After verifying the review file, present the terminal summary:

--- a/skills/deep-review/SKILL.md
+++ b/skills/deep-review/SKILL.md
@@ -280,8 +280,9 @@ On success, verify the doc rather than trusting the return message:
 
 **Stamp the linked issue:** once the doc has passed every verification check above (the same gate that deleted the scratch), post a stamp on the issue this review's branch/PR is tied to. The clean-review case posts no stamp — there is no doc to reference. A fallback-produced doc never passes this gate, so it posts none either. Issue-number resolution (including the skip when none resolves), posting mechanics, marker encoding, and failure handling are defined in [the issue-log spec](../issue-log/SKILL.md).
 
-```bash
-gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
+Compose the body below, write it to a temp file with the Write tool, and post:
+
+```markdown
 <!-- cc-forge-log v1: {"skill":"deep-review","event":"review-written","paths":["docs/reviews/<filename>"]} -->
 
 ### 🔍 /deep-review — review written
@@ -294,8 +295,9 @@ gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 | P1   | <n>   | **P1-1: <short title>** — <one-line description> | <category> | <effort> |
 | P2   | <n>   | **P2-1: <short title>** — <one-line description> | <category> | <effort> |
 | P3   | <n>   | _<n> nice-to-haves: <one-line roll-up of themes> (full detail in the review doc)_ | — | — |
-EOF
-)"
+```
+```bash
+gh issue comment <issue> --repo <owner>/<repo> --body-file <temp-file>
 ```
 
 The table is the same one Step 3's terminal summary builds: every P1 and P2 gets its own row (copy them from the review doc's Summary), P3s are one roll-up row — nothing else in the body.

--- a/skills/issue-log/SKILL.md
+++ b/skills/issue-log/SKILL.md
@@ -53,7 +53,6 @@ Optional keys:
 | `paths` | array | Local doc/worktree paths this event produced or relies on. `unit-complete`/`unit-blocked` stamps always include the plan path (scopes `unit` dedupe across plans). |
 | `pr` | number | PR number for pr events |
 | `tracking` | string | `owner/repo#N` of a tracking issue this event created |
-| `counts` | object | Small integer tallies for multi-item events, e.g. `{"implemented":1,"deferred":2,"skipped":1}` |
 
 **Versioning:** additive-only within v1 — new optional keys, new event names, and new skills never bump the version. A **v2** is required only when an existing key's meaning or read type changes (e.g. `tracking` string → array). Readers skip unknown versions with a warning.
 
@@ -68,7 +67,7 @@ Optional keys:
 | work | `unit-complete` | 🔨 | **Did** (always), **Solved** (only when a problem was solved) |
 | work | `unit-blocked` | ⚠️ | **Blocked:** reason; optional `blocked_by` |
 | deep-review | `review-written` | 🔍 | Severity counts + the findings table from the terminal summary (per-P1/P2 rows, P3 roll-up) |
-| review-walk | `walk-complete` | 🚶 | Summary line + every walked issue as "what — status: why"; tallies in the marker's `counts`; tracking refs for deferred items filed as issues |
+| review-walk | `walk-complete` | 🚶 | Summary line + every walked issue as "what — status: why"; tracking refs for deferred items filed as issues |
 | side-quest | `side-quest-filed` | 🧭 | What was found, tracking-issue link (`tracking`, `followup:true`) |
 | ship | `pr-created` | 🚀 | PR link (`pr`), one-line summary |
 | land | `pr-merged` | ✅ | 2-3 sentence summary of what landed + follow-ups (user-confirmed prose) |
@@ -77,25 +76,28 @@ Event names are these exact strings. New events join this table before any skill
 
 Document-producing skills (brainstorm, plan, deep-review, side-quest) start the human body with a `**Doc:**` field holding the repo-relative doc path, and carry the same path in the marker's `paths`.
 
-## Encoding rule
+## Encoding rules
 
-The payload must never contain the sequence `--` — it can terminate the HTML comment and expose the marker. When serializing any string value (including `unit` titles), replace `--` with `- -`. This applies to the human section's marker line only, not the body below it.
+- The marker line must never contain `--` outside its own delimiters — it can terminate the HTML comment early and expose the marker. When serializing string values (including `unit` titles), replace **every** occurrence, including runs: `---` → `- - -`, `Add --verbose flag` → `Add - -verbose flag`. This applies to the marker line only; the body below it may contain `--` freely.
+- Marker string values are JSON: escape embedded double quotes and backslashes so the payload parses under a strict JSON parser — the reader skips unparseable stamps.
 
 ## Issue-number resolution
 
 Precedence, evaluated top-down; first hit wins:
 
 1. Explicit argument to the skill
-2. Issue already established in session context (e.g. via `/read-issue`, `/triage-issue`)
-3. Branch name: split on `/`, second segment if a positive integer (`feat/57/issue-log-stamps` → 57)
-4. PR body: `Closes #N` / `Fixes #N` / `Resolves #N`
-5. Doc frontmatter (`issue:` in side-quest docs)
+2. Branch name: split on `/`, second segment if a positive integer (`feat/57/issue-log-stamps` → 57)
+3. PR body: `Closes #N` / `Fixes #N` / `Resolves #N`
+4. Doc frontmatter (`issue:` in side-quest docs)
+5. Issue established in session context (e.g. via `/read-issue`, `/triage-issue`) — last resort: a number derived from the branch or PR always outranks a remembered one, so a stale earlier issue never wins over the branch you're on.
+
+Before posting, verify the resolved issue exists (`gh issue view <n>`); if it errors, treat the number as unresolved — this guards against coincidentally-numeric branch segments (`feat/2026/year-name`).
 
 If nothing resolves, **skip the stamp silently** — no error, no prompt. Skills that predate the issue (brainstorm on `main`) skip routinely; this is normal.
 
 ## Posting
 
-- Post with `gh issue comment <n> --repo <owner>/<repo> --body "$(cat <<'EOF' … EOF)"` — always the heredoc form; embedded JSON and backticks break bare `--body` quoting.
+- Compose the full body as text, write it to a temp file with the Write tool, and post with `gh issue comment <n> --repo <owner>/<repo> --body-file <temp-file>`. **Never inline the body in shell** — no `--body "…"`, no heredocs: ported free text (requirements, findings, defer reasons) can contain quotes, backticks, or a line that is literally `EOF`, and none of it may ever be shell-parsed.
 - Fixed-format stamps post **unconfirmed**. Stamps containing drafted prose shown to the user for approval (land's `pr-merged`) keep their existing preview-confirm flow; the marker line is part of the previewed body.
 - **Failure is never fatal and never silent**: if the comment fails after the skill's real work succeeded, report one line — `couldn't stamp #<n>: <reason>` — plus the manual command, and continue. Closed issues accept comments; locked ones don't.
 

--- a/skills/issue-log/SKILL.md
+++ b/skills/issue-log/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: issue-log
+description: Reference spec for the cc-forge issue-log stamp convention — the marker format, event registry, and reader contract. Not a user command.
+user-invocable: false
+disable-model-invocation: true
+---
+
+# Issue-Log Stamp Specification (v1)
+
+The issue-log convention makes a GitHub issue's comment thread a reconstructable work log. Participating skills post **one comment per event** — a "stamp" — with a hidden machine-readable marker on line 1 and a human-readable body below. A reader (the `/daily-review` skill) parses the markers to rebuild what happened without inference.
+
+This file is the single source of truth for every rule that applies to more than one skill. Writer skills embed only their own filled-in stamp template inline and reference this spec for everything else. Never restate a shared rule in a writer skill — not even paraphrased.
+
+## Envelope
+
+```
+<!-- cc-forge-log v1: {"skill":"<skill>","event":"<event>"[, optional keys]} -->
+
+### <glyph> /<skill> — <short outcome>
+
+**<Field>:** <one-liner>
+**<Field>:** <one-liner>
+
+<details><summary>Long content (optional)</summary>
+
+…anything long: lists, excerpts…
+
+</details>
+```
+
+Rules:
+- The marker is **line 1** of the comment body, a **single line**, followed by a blank line. Never inside a code fence or blockquote.
+- The marker is an index, not the content: counts and keys in the JSON; lists and prose in the human section.
+- Long content goes in `<details>` (blank line required after `<summary>` for inner markdown to render).
+- Comment bodies cap at 65,536 characters; truncate the human section if ever near it, never the marker.
+
+## Marker schema (v1)
+
+Required keys:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `skill` | string | Writer skill name (see registry) |
+| `event` | string | Event name (see registry) |
+
+Optional keys:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `unit` | string | Dedupe key for per-unit events: ordinal + title read from the plan's checkbox heading at stamp time, e.g. `"3: Retrofit /plan and /brainstorm stamps"`. Never the in-session task title. |
+| `followup` | bool | Marks the stamp as follow-up material for the daily reviewer |
+| `blocked_by` | array | Refs gating a follow-up, each `owner/repo#N` |
+| `paths` | array | Local doc/worktree paths this event produced or relies on. `unit-complete`/`unit-blocked` stamps always include the plan path (scopes `unit` dedupe across plans). |
+| `pr` | number | PR number for pr events |
+| `tracking` | string | `owner/repo#N` of a tracking issue this event created |
+| `counts` | object | Small integer tallies for multi-item events, e.g. `{"implemented":1,"deferred":2,"skipped":1}` |
+
+**Versioning:** additive-only within v1 — new optional keys, new event names, and new skills never bump the version. A **v2** is required only when an existing key's meaning or read type changes (e.g. `tracking` string → array). Readers skip unknown versions with a warning.
+
+## Event registry
+
+| Skill | Event | Glyph | Payload fields (human section) |
+|---|---|---|---|
+| brainstorm | `requirements-written` | 💡 | Doc path, 2-4 key decisions, unresolved questions |
+| plan | `plan-written` | 📋 | Plan path, 1-2 sentence scope, unit count, origin brainstorm path + key decisions |
+| tree | `worktree-created` | 🌳 | Branch, worktree path (also in `paths`) |
+| branch-from-issue | `branch-created` | 🌱 | Branch |
+| work | `unit-complete` | 🔨 | **Did** (always), **Solved** (only when a problem was solved) |
+| work | `unit-blocked` | ⚠️ | **Blocked:** reason; optional `blocked_by` |
+| deep-review | `review-written` | 🔍 | Doc path, finding counts by severity, top 2-3 findings |
+| review-walk | `walk-complete` | 🚶 | Implemented / deferred / skipped one-liners; tallies in the marker's `counts`; `tracking` refs per created issue in the human section |
+| side-quest | `side-quest-filed` | 🧭 | What was found, tracking-issue link (`tracking`, `followup:true`) |
+| ship | `pr-created` | 🚀 | PR link (`pr`), one-line summary |
+| land | `pr-merged` | ✅ | Resolution summary (user-confirmed prose) |
+
+Event names are these exact strings. New events join this table before any skill emits them.
+
+## Encoding rule
+
+The payload must never contain the sequence `--` — it can terminate the HTML comment and expose the marker. When serializing any string value (including `unit` titles), replace `--` with `- -`. This applies to the human section's marker line only, not the body below it.
+
+## Issue-number resolution
+
+Precedence, evaluated top-down; first hit wins:
+
+1. Explicit argument to the skill
+2. Issue already established in session context (e.g. via `/read-issue`, `/triage-issue`)
+3. Branch name: split on `/`, second segment if a positive integer (`feat/57/issue-log-stamps` → 57)
+4. PR body: `Closes #N` / `Fixes #N` / `Resolves #N`
+5. Doc frontmatter (`issue:` in side-quest docs)
+
+If nothing resolves, **skip the stamp silently** — no error, no prompt. Skills that predate the issue (brainstorm on `main`) skip routinely; this is normal.
+
+## Posting
+
+- Post with `gh issue comment <n> --repo <owner>/<repo> --body "$(cat <<'EOF' … EOF)"` — always the heredoc form; embedded JSON and backticks break bare `--body` quoting.
+- Fixed-format stamps post **unconfirmed**. Stamps containing drafted prose shown to the user for approval (land's `pr-merged`) keep their existing preview-confirm flow; the marker line is part of the previewed body.
+- **Failure is never fatal and never silent**: if the comment fails after the skill's real work succeeded, report one line — `couldn't stamp #<n>: <reason>` — plus the manual command, and continue. Closed issues accept comments; locked ones don't.
+
+## Dedupe semantics
+
+Writers never dedupe; re-runs may emit duplicate events (re-ship after a PR close, worktree recreate, resumed `/work` re-stamping a unit). Concurrent sessions are safe by construction — comments are append-only. The **reader** applies latest-wins per `(skill, event, unit)`, scoping `unit` by the plan path carried in `paths`.
+
+## Reader contract
+
+Consumers (the `/daily-review` skill) must:
+
+1. Fetch comments via `gh api repos/{owner}/{repo}/issues/{n}/comments --paginate` (raw bodies; `gh issue view --json comments` caps at ~100).
+2. Keep only comments whose author is the authenticated login **and** whose first line matches `^<!-- cc-forge-log v(\d+): (\{.*\}) -->$` — both checks, always (quote-replies copy raw markers into human comments).
+3. Dispatch on the version capture; skip unknown versions and unparseable JSON with a one-line warning, never fail the run.
+4. Apply latest-wins dedupe as above.
+5. Treat `paths` values as machine-scoped: check existence before presenting; label dead paths ("worktree removed" / "not on this machine").
+
+## Worked example
+
+A `/work` stamp for unit 3 of a plan, posted to issue #57:
+
+```markdown
+<!-- cc-forge-log v1: {"skill":"work","event":"unit-complete","unit":"3: Retrofit /plan and /brainstorm stamps","paths":["docs/plans/2026-07-21-001-feat-issue-log-standard-plan.md"]} -->
+
+### 🔨 /work — unit 3: Retrofit /plan and /brainstorm stamps
+
+**Did:** Added plan-written stamp after issue creation; brainstorm stamps only when an issue is known in session.
+**Solved:** Plan stamps fired before the issue existed — moved the stamp after the optional issue-creation step.
+```
+
+Round-trip check: the REST API returns this body byte-identical; the reader regex captures version `1` and valid JSON.

--- a/skills/issue-log/SKILL.md
+++ b/skills/issue-log/SKILL.md
@@ -61,17 +61,17 @@ Optional keys:
 
 | Skill | Event | Glyph | Payload fields (human section) |
 |---|---|---|---|
-| brainstorm | `requirements-written` | 💡 | Doc path, 2-4 key decisions, unresolved questions |
-| plan | `plan-written` | 📋 | Plan path, 1-2 sentence scope, unit count, origin brainstorm path + key decisions |
+| brainstorm | `requirements-written` | 🧠 | Doc path, full requirements list (direct port from the doc) |
+| plan | `plan-written` | 📋 | Plan path, unit count, every unit enumerated with a one-sentence summary |
 | tree | `worktree-created` | 🌳 | Branch, worktree path (also in `paths`) |
 | branch-from-issue | `branch-created` | 🌱 | Branch |
 | work | `unit-complete` | 🔨 | **Did** (always), **Solved** (only when a problem was solved) |
 | work | `unit-blocked` | ⚠️ | **Blocked:** reason; optional `blocked_by` |
-| deep-review | `review-written` | 🔍 | Doc path, finding counts by severity, top 2-3 findings |
-| review-walk | `walk-complete` | 🚶 | Implemented / deferred / skipped one-liners; tallies in the marker's `counts`; `tracking` refs per created issue in the human section |
+| deep-review | `review-written` | 🔍 | Severity counts + the findings table from the terminal summary (per-P1/P2 rows, P3 roll-up) |
+| review-walk | `walk-complete` | 🚶 | Summary line + every walked issue as "what — status: why"; tallies in the marker's `counts` |
 | side-quest | `side-quest-filed` | 🧭 | What was found, tracking-issue link (`tracking`, `followup:true`) |
 | ship | `pr-created` | 🚀 | PR link (`pr`), one-line summary |
-| land | `pr-merged` | ✅ | Resolution summary (user-confirmed prose) |
+| land | `pr-merged` | ✅ | 2-3 sentence summary of what landed + follow-ups (user-confirmed prose) |
 
 Event names are these exact strings. New events join this table before any skill emits them.
 

--- a/skills/issue-log/SKILL.md
+++ b/skills/issue-log/SKILL.md
@@ -68,12 +68,14 @@ Optional keys:
 | work | `unit-complete` | 🔨 | **Did** (always), **Solved** (only when a problem was solved) |
 | work | `unit-blocked` | ⚠️ | **Blocked:** reason; optional `blocked_by` |
 | deep-review | `review-written` | 🔍 | Severity counts + the findings table from the terminal summary (per-P1/P2 rows, P3 roll-up) |
-| review-walk | `walk-complete` | 🚶 | Summary line + every walked issue as "what — status: why"; tallies in the marker's `counts` |
+| review-walk | `walk-complete` | 🚶 | Summary line + every walked issue as "what — status: why"; tallies in the marker's `counts`; tracking refs for deferred items filed as issues |
 | side-quest | `side-quest-filed` | 🧭 | What was found, tracking-issue link (`tracking`, `followup:true`) |
 | ship | `pr-created` | 🚀 | PR link (`pr`), one-line summary |
 | land | `pr-merged` | ✅ | 2-3 sentence summary of what landed + follow-ups (user-confirmed prose) |
 
 Event names are these exact strings. New events join this table before any skill emits them.
+
+Document-producing skills (brainstorm, plan, deep-review, side-quest) start the human body with a `**Doc:**` field holding the repo-relative doc path, and carry the same path in the marker's `paths`.
 
 ## Encoding rule
 

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -157,14 +157,22 @@ Typical flow: open the PR with `/ship` → run `/land` → answer the confirm pr
 36. **Skip entirely if** there's no `<issue>` from step 10, or the merge in Phase 9 did not succeed (never comment "resolved" on an issue whose PR isn't merged). A squash-merge with `Closes #<issue>` in the PR body auto-closes the issue; this comment adds the human-readable *what-shipped*, it does not close anything itself.
 37. **Verify the issue is real and open-or-just-closed:** `gh issue view <issue> --json number,state,title`. If it errors (wrong number, no access), skip with a one-line note — don't fabricate. If `state` is already `CLOSED` from before this PR, still comment (the resolution context is useful) but don't imply this PR closed it.
 38. **Draft a ≤3-sentence summary** of what shipped, aimed at someone who filed or is watching the issue — plain language, no diff stats or file lists. Source it from the PR title, the `## Related` summary you just composed, and the merged diff. Say what changed and, if not obvious, the effect. Keep it to at most three sentences.
-39. **Compose the comment:**
+39. **Compose the comment.** Composition always produces the whole body — line 1 is the issue-log marker per [the issue-log spec](../issue-log/SKILL.md), then a blank line, then the resolution text — so every recompose (including step 40's Edit-summary branch) re-includes the marker and the preview always shows it:
     ```markdown
+    <!-- cc-forge-log v1: {"skill":"land","event":"pr-merged","pr":<N>} -->
+
     Resolved by #<N> (merged).
 
     <≤3-sentence summary>
     ```
-    (If the issue was already closed before this PR, replace the first line with `Addressed by #<N> (merged).`)
-40. **Confirm before posting** via `AskUserQuestion`, showing the composed comment in a `preview`: **Post to issue** (default) / **Edit summary** (free-form revised summary, recompose, re-confirm) / **Skip** (don't comment). On Post: `gh issue comment <issue> --body "<comment>"`.
+    (If the issue was already closed before this PR, replace the `Resolved by` line with `Addressed by #<N> (merged).`)
+40. **Confirm before posting** via `AskUserQuestion`, showing the composed comment in a `preview`: **Post to issue** (default) / **Edit summary** (free-form revised summary, recompose per step 39, re-confirm) / **Skip** (don't comment). On Post:
+    ```bash
+    gh issue comment <issue> --body "$(cat <<'EOF'
+    <composed comment>
+    EOF
+    )"
+    ```
 41. Report whether the issue comment posted, was edited, or was skipped. A failed `gh issue comment` is not fatal — the PR is already merged; report the failure and the manual command, don't roll anything back.
 
 ## Rules

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -157,15 +157,18 @@ Typical flow: open the PR with `/ship` → run `/land` → answer the confirm pr
 36. **Skip entirely if** there's no `<issue>` from step 10, or the merge in Phase 9 did not succeed (never comment "resolved" on an issue whose PR isn't merged). A squash-merge with `Closes #<issue>` in the PR body auto-closes the issue; this comment adds the human-readable *what-shipped*, it does not close anything itself.
 37. **Verify the issue is real and open-or-just-closed:** `gh issue view <issue> --json number,state,title`. If it errors (wrong number, no access), skip with a one-line note — don't fabricate. If `state` is already `CLOSED` from before this PR, still comment (the resolution context is useful) but don't imply this PR closed it.
 38. **Draft a ≤3-sentence summary** of what shipped, aimed at someone who filed or is watching the issue — plain language, no diff stats or file lists. Source it from the PR title, the `## Related` summary you just composed, and the merged diff. Say what changed and, if not obvious, the effect. Keep it to at most three sentences.
-39. **Compose the comment.** Composition always produces the whole body — line 1 is the issue-log marker per [the issue-log spec](../issue-log/SKILL.md), then a blank line, then the resolution text — so every recompose (including step 40's Edit-summary branch) re-includes the marker and the preview always shows it:
+39. **Compose the comment.** Composition always produces the whole body — so every recompose (including step 40's Edit-summary branch) re-includes the marker line and the preview always shows it:
     ```markdown
     <!-- cc-forge-log v1: {"skill":"land","event":"pr-merged","pr":<N>} -->
 
-    Resolved by #<N> (merged).
+    ### ✅ /land — PR #<N> merged
 
-    <≤3-sentence summary>
+    <2-3 sentence summary of what landed, from step 38>
+
+    **Follow-ups:**
+    - <known follow-up: deferred review items, side-quests, or debt discovered during this branch>
     ```
-    (If the issue was already closed before this PR, replace the `Resolved by` line with `Addressed by #<N> (merged).`)
+    Omit the **Follow-ups** section when none are known. If the issue was already closed before this PR, say so in the summary wording rather than implying this PR closed it.
 40. **Confirm before posting** via `AskUserQuestion`, showing the composed comment in a `preview`: **Post to issue** (default) / **Edit summary** (free-form revised summary, recompose per step 39, re-confirm) / **Skip** (don't comment). On Post:
     ```bash
     gh issue comment <issue> --body "$(cat <<'EOF'

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -157,7 +157,7 @@ Typical flow: open the PR with `/ship` → run `/land` → answer the confirm pr
 36. **Skip entirely if** there's no `<issue>` from step 10, or the merge in Phase 9 did not succeed (never comment "resolved" on an issue whose PR isn't merged). A squash-merge with `Closes #<issue>` in the PR body auto-closes the issue; this comment adds the human-readable *what-shipped*, it does not close anything itself.
 37. **Verify the issue is real and open-or-just-closed:** `gh issue view <issue> --json number,state,title`. If it errors (wrong number, no access), skip with a one-line note — don't fabricate. If `state` is already `CLOSED` from before this PR, still comment (the resolution context is useful) but don't imply this PR closed it.
 38. **Draft a ≤3-sentence summary** of what shipped, aimed at someone who filed or is watching the issue — plain language, no diff stats or file lists. Source it from the PR title, the `## Related` summary you just composed, and the merged diff. Say what changed and, if not obvious, the effect. Keep it to at most three sentences.
-39. **Compose the comment.** Composition always produces the whole body — so every recompose (including step 40's Edit-summary branch) re-includes the marker line and the preview always shows it:
+39. **Compose the comment** — the whole body, marker line first (a recompose after Edit summary produces this same shape):
     ```markdown
     <!-- cc-forge-log v1: {"skill":"land","event":"pr-merged","pr":<N>} -->
 
@@ -169,12 +169,9 @@ Typical flow: open the PR with `/ship` → run `/land` → answer the confirm pr
     - <known follow-up: deferred review items, side-quests, or debt discovered during this branch>
     ```
     Omit the **Follow-ups** section when none are known. If the issue was already closed before this PR, say so in the summary wording rather than implying this PR closed it.
-40. **Confirm before posting** via `AskUserQuestion`, showing the composed comment in a `preview`: **Post to issue** (default) / **Edit summary** (free-form revised summary, recompose per step 39, re-confirm) / **Skip** (don't comment). On Post:
+40. **Confirm before posting** via `AskUserQuestion`, showing the composed comment in a `preview`: **Post to issue** (default) / **Edit summary** (free-form revised summary, recompose per step 39, re-confirm) / **Skip** (don't comment). On Post: write the composed comment to a temp file with the Write tool, then
     ```bash
-    gh issue comment <issue> --body "$(cat <<'EOF'
-    <composed comment>
-    EOF
-    )"
+    gh issue comment <issue> --repo <owner>/<repo> --body-file <temp-file>
     ```
 41. Report whether the issue comment posted, was edited, or was skipped. A failed `gh issue comment` is not fatal — the PR is already merged; report the failure and the manual command, don't roll anything back.
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -604,7 +604,7 @@ gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
 
 ### 📋 /plan — <plan title>
 
-**Plan:** `docs/plans/<plan-filename>` — <N> implementation units
+**Doc:** `docs/plans/<plan-filename>` — <N> implementation units
 **Units:**
 1. <Unit name> — <one-sentence summary of what it will do>
 2. <Unit name> — <one-sentence summary of what it will do>

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -590,16 +590,9 @@ Plan written to docs/plans/[filename]
 
 #### 5.2b Stamp the Origin Issue
 
-Post an issue-log stamp for the plan — once, at the first point an issue number is available. Envelope, resolution precedence, posting, and skip/failure rules are in [the issue-log spec](../issue-log/SKILL.md).
+Post the plan-written stamp once, at the first point an issue number is resolvable per [the issue-log spec](../issue-log/SKILL.md) — immediately after writing the plan file, or (when nothing resolves yet) right after 5.3's Create Issue step creates one; skipped when neither happens. GitHub tracker only — when the tracker is Linear, skip with a one-line note. Compose the body below, write it to a temp file with the Write tool, and post:
 
-- If an issue is already resolvable now (per the spec's resolution precedence), post the stamp below immediately after writing the plan file.
-- Otherwise, defer: if the user selects **Create Issue** in 5.3, the Issue Creation section posts this same stamp on the just-created issue.
-- If neither happens, the stamp is skipped.
-
-Never post the stamp twice.
-
-```bash
-gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
+```markdown
 <!-- cc-forge-log v1: {"skill":"plan","event":"plan-written","paths":["docs/plans/<plan-filename>"]} -->
 
 ### 📋 /plan — <plan title>
@@ -608,8 +601,9 @@ gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
 **Units:**
 1. <Unit name> — <one-sentence summary of what it will do>
 2. <Unit name> — <one-sentence summary of what it will do>
-EOF
-)"
+```
+```bash
+gh issue comment <issue-number> --repo <owner>/<repo> --body-file <temp-file>
 ```
 
 Enumerate every implementation unit, in plan order.
@@ -671,7 +665,7 @@ When the user selects "Create Issue", detect their project tracker from `AGENTS.
 
 After issue creation:
 - Display the issue URL
-- If the plan stamp was not posted in 5.2b (no issue was resolvable then), post it now on the just-created issue using the stamp block in 5.2b — never twice
+- If the plan stamp was not posted in 5.2b (no issue was resolvable then) and the tracker is GitHub, post it now on the just-created issue using the stamp block in 5.2b — never twice, and never for Linear issues
 - Ask whether to proceed to `/work`
 
 NEVER CODE! Research, decide, and write the plan.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -605,20 +605,14 @@ gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
 ### 📋 /plan — <plan title>
 
 **Plan:** `docs/plans/<plan-filename>` — <N> implementation units
-**Scope:** <1-2 sentence scope summary>
-**Origin:** `docs/brainstorms/<origin-filename>`
-
-<details><summary>Origin key decisions</summary>
-
-- <key decision carried from the origin doc>
-- <key decision carried from the origin doc>
-
-</details>
+**Units:**
+1. <Unit name> — <one-sentence summary of what it will do>
+2. <Unit name> — <one-sentence summary of what it will do>
 EOF
 )"
 ```
 
-Omit the **Origin** line and the `<details>` block when the plan has no `origin:` frontmatter.
+Enumerate every implementation unit, in plan order.
 
 #### 5.3 Post-Generation Options
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -588,6 +588,38 @@ Plan written to docs/plans/[filename]
 
 **Pipeline mode:** If invoked from an automated workflow such as LFG, SLFG, or any `disable-model-invocation` context, skip interactive questions. Make the needed choices automatically and proceed to writing the plan.
 
+#### 5.2b Stamp the Origin Issue
+
+Post an issue-log stamp for the plan — once, at the first point an issue number is available. Envelope, resolution precedence, posting, and skip/failure rules are in [the issue-log spec](../issue-log/SKILL.md).
+
+- If an issue is already resolvable now (per the spec's resolution precedence), post the stamp below immediately after writing the plan file.
+- Otherwise, defer: if the user selects **Create Issue** in 5.3, the Issue Creation section posts this same stamp on the just-created issue.
+- If neither happens, the stamp is skipped.
+
+Never post the stamp twice.
+
+```bash
+gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
+<!-- cc-forge-log v1: {"skill":"plan","event":"plan-written","paths":["docs/plans/<plan-filename>"]} -->
+
+### 📋 /plan — <plan title>
+
+**Plan:** `docs/plans/<plan-filename>` — <N> implementation units
+**Scope:** <1-2 sentence scope summary>
+**Origin:** `docs/brainstorms/<origin-filename>`
+
+<details><summary>Origin key decisions</summary>
+
+- <key decision carried from the origin doc>
+- <key decision carried from the origin doc>
+
+</details>
+EOF
+)"
+```
+
+Omit the **Origin** line and the `<details>` block when the plan has no `origin:` frontmatter.
+
 #### 5.3 Post-Generation Options
 
 After writing the plan file, present the options using the platform's blocking question tool when available (see Interaction Method). Otherwise present numbered options in chat and wait for the user's reply before proceeding.
@@ -645,6 +677,7 @@ When the user selects "Create Issue", detect their project tracker from `AGENTS.
 
 After issue creation:
 - Display the issue URL
+- If the plan stamp was not posted in 5.2b (no issue was resolvable then), post it now on the just-created issue using the stamp block in 5.2b — never twice
 - Ask whether to proceed to `/work`
 
 NEVER CODE! Research, decide, and write the plan.

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -241,7 +241,8 @@ After all issues are terminal:
 - Show counts by terminal status: `done`, `deferred`, `wont-fix`.
 - List deferred items with their reasons (the user may want these as follow-up
   tickets).
-- Stamp the walk outcome (Step 8a).
+- Offer tracking issues for the deferred items (Step 8a), then stamp the walk
+  outcome (Step 8b).
 - Suggest next steps:
   - If any `done` issues produced code changes, check whether the current branch has
     an open PR (`gh pr view --json state,number`):
@@ -251,10 +252,48 @@ After all issues are terminal:
       deferred / skipped). That skill owns the commit+push+comment; don't do it here.
     - **No PR**: suggest `/ship`.
 
-  - If many `deferred` items exist → suggest opening follow-up issues via
-    `/issue-from-context` or `/side-quest`.
+### 8a. Tracking Issues for Deferred Items
 
-### 8a. Stamp the Walk Outcome
+Derive the deferred list by re-reading the doc's `Status:` lines — never from
+session memory — so a walk resumed across sessions covers every deferred issue,
+not just this session's. If none are `deferred`, skip to 8b.
+
+Resolve `<owner>/<repo>` from `git remote get-url origin`. Then ask once via
+`AskUserQuestion`:
+
+> "File tracking issues for the <n> deferred items?"
+
+- **Create all** — one issue per deferred item.
+- **Pick which** — let the user select a subset, then create those.
+- **Skip** — create nothing.
+
+For each item being created, build the body from the shared
+[issue template](../issue-from-context/issue-template.md) — same structure
+`/issue-from-context` uses — filled from the review doc:
+
+- **Summary**: the finding's one-line description plus its defer reason
+- **Evidence**: the finding's `Problem:` section
+- **Expected**: the finding's `Fix:` section
+- **Actual (if bug)** / **Repro (if applicable)**: fill when the finding is a
+  bug with observed behavior; otherwise "n/a"
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "<the issue's title from its review-doc heading>" \
+  --label "follow-up" \
+  --body "$(cat <<'EOF'
+<filled issue template>
+EOF
+)"
+```
+
+- If the command errors because the `follow-up` label doesn't exist, re-run
+  without `--label` and tell the user the label is missing on this repo.
+- Capture each created issue's number from the output URL as
+  `<owner>/<repo>#<n>` — Step 8b lists these refs.
+
+### 8b. Stamp the Walk Outcome
 
 The stamp fires only here, at final summary — a walk abandoned before Step 8
 posts nothing. Statuses come from the doc's `Status:` lines (`done` →
@@ -265,7 +304,7 @@ in [the issue-log spec](../issue-log/SKILL.md).
 
 ```bash
 gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
-<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","counts":{"implemented":<n>,"deferred":<n>,"skipped":<n>}} -->
+<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","counts":{"implemented":<n>,"deferred":<n>,"skipped":<n>},"followup":true} -->
 
 ### 🚶 /review-walk — walk complete
 
@@ -273,11 +312,14 @@ gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 **Issues:**
 - <P<X>-<N>: one line on what the issue is> — <status>: <why>
 - <P<X>-<N>: one line on what the issue is> — <status>: <why>
+**Tracking:** <owner>/<repo>#<n>, one ref per issue created in 8a
 EOF
 )"
 ```
 
-Enumerate every walked issue, in doc order.
+Enumerate every walked issue, in doc order. Include `"followup":true` and the
+`**Tracking:**` line only when 8a created at least one tracking issue; omit
+both otherwise.
 
 ## Fallback Mode Details
 

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -310,8 +310,12 @@ gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 
 **Summary:** <n> issues walked — <n> implemented, <n> deferred, <n> skipped
 **Issues:**
-- <P<X>-<N>: one line on what the issue is> — <status>: <why>
-- <P<X>-<N>: one line on what the issue is> — <status>: <why>
+- <P<X>-<N>: short title>
+  - <one line on what the issue is>
+  - <status>: <why>
+- <P<X>-<N>: short title>
+  - <one line on what the issue is>
+  - <status>: <why>
 **Tracking:** <owner>/<repo>#<n>, one ref per issue created in 8a
 EOF
 )"

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -241,8 +241,7 @@ After all issues are terminal:
 - Show counts by terminal status: `done`, `deferred`, `wont-fix`.
 - List deferred items with their reasons (the user may want these as follow-up
   tickets).
-- Offer tracking issues for the deferred items (Step 8a), then stamp the walk
-  outcome (Step 8b).
+- Stamp the walk outcome (Step 8a).
 - Suggest next steps:
   - If any `done` issues produced code changes, check whether the current branch has
     an open PR (`gh pr view --json state,number`):
@@ -252,71 +251,33 @@ After all issues are terminal:
       deferred / skipped). That skill owns the commit+push+comment; don't do it here.
     - **No PR**: suggest `/ship`.
 
-### 8a. Tracking Issues for Deferred Items
+  - If many `deferred` items exist → suggest opening follow-up issues via
+    `/issue-from-context` or `/side-quest`.
 
-Derive the deferred list by re-reading the doc's `Status:` lines — never from
-session memory — so a walk resumed across sessions covers every deferred issue,
-not just this session's. If none are `deferred`, skip to 8b.
-
-Resolve `<owner>/<repo>` from `git remote get-url origin`. Then ask once via
-`AskUserQuestion`:
-
-> "File tracking issues for the <n> deferred items?"
-
-- **Create all** — one issue per deferred item.
-- **Pick which** — let the user select a subset, then create those.
-- **Skip** — create nothing.
-
-For each item being created:
-
-```bash
-gh issue create \
-  --repo <owner>/<repo> \
-  --title "<the issue's title from its review-doc heading>" \
-  --label "follow-up" \
-  --body "$(cat <<'EOF'
-<the issue's description from the review doc — Problem: and Fix: — plus its Defer reason>
-EOF
-)"
-```
-
-- If the command errors because the `follow-up` label doesn't exist, re-run
-  without `--label` and tell the user the label is missing on this repo.
-- Capture each created issue's number from the output URL as
-  `<owner>/<repo>#<n>` — Step 8b lists these refs.
-
-### 8b. Stamp the Walk Outcome
+### 8a. Stamp the Walk Outcome
 
 The stamp fires only here, at final summary — a walk abandoned before Step 8
-posts nothing. Counts come from the doc's `Status:` lines (`done` → implemented,
-`deferred` → deferred, `wont-fix` → skipped), so resumed walks report correctly.
-Issue-number resolution (including the skip when none resolves), posting
-mechanics, marker encoding, and failure handling are defined in
-[the issue-log spec](../issue-log/SKILL.md).
+posts nothing. Statuses come from the doc's `Status:` lines (`done` →
+implemented, `deferred` → deferred, `wont-fix` → skipped), so resumed walks
+report correctly. Issue-number resolution (including the skip when none
+resolves), posting mechanics, marker encoding, and failure handling are defined
+in [the issue-log spec](../issue-log/SKILL.md).
 
 ```bash
 gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
-<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","counts":{"implemented":<n>,"deferred":<n>,"skipped":<n>},"followup":true} -->
+<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","counts":{"implemented":<n>,"deferred":<n>,"skipped":<n>}} -->
 
 ### 🚶 /review-walk — walk complete
 
-**Implemented (<n>):**
-- <P<X>-<N>: one-liner>
-**Deferred (<n>):**
-- <P<X>-<N>: one-liner — defer reason>
-**Skipped (<n>):**
-- <P<X>-<N>: one-liner>
-**Tracking:** <owner>/<repo>#<n>, one ref per issue created in 8a
+**Summary:** <n> issues walked — <n> implemented, <n> deferred, <n> skipped
+**Issues:**
+- <P<X>-<N>: one line on what the issue is> — <status>: <why>
+- <P<X>-<N>: one line on what the issue is> — <status>: <why>
 EOF
 )"
 ```
 
-Adjustments before posting:
-- Include `"followup":true` only when 8a created at least one tracking issue;
-  omit the key otherwise, and drop the `**Tracking:**` line with it.
-- Tracking refs live in the human section only — the marker's `tracking` key is
-  single-string and is not used for the batch case.
-- Drop any Implemented/Deferred/Skipped block whose count is zero.
+Enumerate every walked issue, in doc order.
 
 ## Fallback Mode Details
 

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -241,6 +241,8 @@ After all issues are terminal:
 - Show counts by terminal status: `done`, `deferred`, `wont-fix`.
 - List deferred items with their reasons (the user may want these as follow-up
   tickets).
+- Offer tracking issues for the deferred items (Step 8a), then stamp the walk
+  outcome (Step 8b).
 - Suggest next steps:
   - If any `done` issues produced code changes, check whether the current branch has
     an open PR (`gh pr view --json state,number`):
@@ -249,8 +251,72 @@ After all issues are terminal:
       branch, and posts a PR comment mapping each finding to its outcome (fixed /
       deferred / skipped). That skill owns the commit+push+comment; don't do it here.
     - **No PR**: suggest `/ship`.
-  - If many `deferred` items exist → suggest opening follow-up issues via
-    `/issue-from-context` or `/side-quest`.
+
+### 8a. Tracking Issues for Deferred Items
+
+Derive the deferred list by re-reading the doc's `Status:` lines — never from
+session memory — so a walk resumed across sessions covers every deferred issue,
+not just this session's. If none are `deferred`, skip to 8b.
+
+Resolve `<owner>/<repo>` from `git remote get-url origin`. Then ask once via
+`AskUserQuestion`:
+
+> "File tracking issues for the <n> deferred items?"
+
+- **Create all** — one issue per deferred item.
+- **Pick which** — let the user select a subset, then create those.
+- **Skip** — create nothing.
+
+For each item being created:
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "<the issue's title from its review-doc heading>" \
+  --label "follow-up" \
+  --body "$(cat <<'EOF'
+<the issue's description from the review doc — Problem: and Fix: — plus its Defer reason>
+EOF
+)"
+```
+
+- If the command errors because the `follow-up` label doesn't exist, re-run
+  without `--label` and tell the user the label is missing on this repo.
+- Capture each created issue's number from the output URL as
+  `<owner>/<repo>#<n>` — Step 8b lists these refs.
+
+### 8b. Stamp the Walk Outcome
+
+The stamp fires only here, at final summary — a walk abandoned before Step 8
+posts nothing. Counts come from the doc's `Status:` lines (`done` → implemented,
+`deferred` → deferred, `wont-fix` → skipped), so resumed walks report correctly.
+Issue-number resolution (including the skip when none resolves), posting
+mechanics, marker encoding, and failure handling are defined in
+[the issue-log spec](../issue-log/SKILL.md).
+
+```bash
+gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
+<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","counts":{"implemented":<n>,"deferred":<n>,"skipped":<n>},"followup":true} -->
+
+### 🚶 /review-walk — walk complete
+
+**Implemented (<n>):**
+- <P<X>-<N>: one-liner>
+**Deferred (<n>):**
+- <P<X>-<N>: one-liner — defer reason>
+**Skipped (<n>):**
+- <P<X>-<N>: one-liner>
+**Tracking:** <owner>/<repo>#<n>, one ref per issue created in 8a
+EOF
+)"
+```
+
+Adjustments before posting:
+- Include `"followup":true` only when 8a created at least one tracking issue;
+  omit the key otherwise, and drop the `**Tracking:**` line with it.
+- Tracking refs live in the human section only — the marker's `tracking` key is
+  single-string and is not used for the batch case.
+- Drop any Implemented/Deferred/Skipped block whose count is zero.
 
 ## Fallback Mode Details
 

--- a/skills/review-walk/SKILL.md
+++ b/skills/review-walk/SKILL.md
@@ -267,6 +267,9 @@ Resolve `<owner>/<repo>` from `git remote get-url origin`. Then ask once via
 - **Pick which** — let the user select a subset, then create those.
 - **Skip** — create nothing.
 
+Skip any deferred item whose doc entry already carries a `Tracking:` line — a
+resumed walk must not re-file issues that exist.
+
 For each item being created, build the body from the shared
 [issue template](../issue-from-context/issue-template.md) — same structure
 `/issue-from-context` uses — filled from the review doc:
@@ -277,21 +280,26 @@ For each item being created, build the body from the shared
 - **Actual (if bug)** / **Repro (if applicable)**: fill when the finding is a
   bug with observed behavior; otherwise "n/a"
 
+Write the filled template to a temp file with the Write tool, then:
+
 ```bash
 gh issue create \
   --repo <owner>/<repo> \
   --title "<the issue's title from its review-doc heading>" \
   --label "follow-up" \
-  --body "$(cat <<'EOF'
-<filled issue template>
-EOF
-)"
+  --body-file <temp-file>
 ```
 
 - If the command errors because the `follow-up` label doesn't exist, re-run
   without `--label` and tell the user the label is missing on this repo.
-- Capture each created issue's number from the output URL as
-  `<owner>/<repo>#<n>` — Step 8b lists these refs.
+- **Immediately after each successful create**, add a `Tracking:
+  <owner>/<repo>#<n>` line under that item's `Status:` line in the review doc —
+  this is the durable record; Step 8b's list is derived from it, and an
+  interrupted batch resumes without duplicates.
+- If a create fails for any other reason, note the item and continue with the
+  rest; after the loop, report which deferred items did **not** get a tracking
+  issue. Step 8b's stamp must reflect the shortfall (e.g. `Tracking: 2 of 4
+  filed — P2-3, P2-5 failed`), never silently list only the successes.
 
 ### 8b. Stamp the Walk Outcome
 
@@ -302,9 +310,10 @@ report correctly. Issue-number resolution (including the skip when none
 resolves), posting mechanics, marker encoding, and failure handling are defined
 in [the issue-log spec](../issue-log/SKILL.md).
 
-```bash
-gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
-<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","counts":{"implemented":<n>,"deferred":<n>,"skipped":<n>},"followup":true} -->
+Compose the body below, write it to a temp file with the Write tool, and post:
+
+```markdown
+<!-- cc-forge-log v1: {"skill":"review-walk","event":"walk-complete","followup":true} -->
 
 ### 🚶 /review-walk — walk complete
 
@@ -316,9 +325,10 @@ gh issue comment <issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 - <P<X>-<N>: short title>
   - <one line on what the issue is>
   - <status>: <why>
-**Tracking:** <owner>/<repo>#<n>, one ref per issue created in 8a
-EOF
-)"
+**Tracking:** <owner>/<repo>#<n>, one ref per `Tracking:` line in the doc — note any shortfall from 8a
+```
+```bash
+gh issue comment <issue> --repo <owner>/<repo> --body-file <temp-file>
 ```
 
 Enumerate every walked issue, in doc order. Include `"followup":true` and the

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -104,6 +104,19 @@ Do NOT proceed with any commits or pushes on main/master.
 
 11. Output the PR URL.
 
+12. **Post an issue-log stamp on the linked issue** (skip if `<issue-number>` from step 10a is none). Post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
+    ```bash
+    gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
+    <!-- cc-forge-log v1: {"skill":"ship","event":"pr-created","pr":<pr-number>} -->
+
+    ### 🚀 /ship — PR created
+
+    **PR:** <pr-url>
+    **Summary:** <one-line summary of the PR>
+    EOF
+    )"
+    ```
+
 ## Rules
 
 - **Repo scoping**: Only commit and push changes within the current repository root. Never commit changes from other repositories.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -104,17 +104,17 @@ Do NOT proceed with any commits or pushes on main/master.
 
 11. Output the PR URL.
 
-12. **Post an issue-log stamp on the linked issue** (skip if `<issue-number>` from step 10a is none). Post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
-    ```bash
-    gh issue comment <issue-number> --repo <owner>/<repo> --body "$(cat <<'EOF'
+12. **Post an issue-log stamp on the linked issue** (skip if `<issue-number>` from step 10a is none). Compose the body below, write it to a temp file with the Write tool, and post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
+    ```markdown
     <!-- cc-forge-log v1: {"skill":"ship","event":"pr-created","pr":<pr-number>} -->
 
     ### 🚀 /ship — PR created
 
     **PR:** <pr-url>
     **Summary:** <one-line summary of the PR>
-    EOF
-    )"
+    ```
+    ```bash
+    gh issue comment <issue-number> --repo <owner>/<repo> --body-file <temp-file>
     ```
 
 ## Rules

--- a/skills/side-quest/SKILL.md
+++ b/skills/side-quest/SKILL.md
@@ -125,10 +125,11 @@ Posting mechanics, marker encoding, confirmation posture, and failure handling a
 
 ```bash
 gh issue comment <originating-issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
-<!-- cc-forge-log v1: {"skill":"side-quest","event":"side-quest-filed","followup":true,"tracking":"<owner>/<repo>#<tracking-issue>","blocked_by":["<owner>/<repo>#<originating-issue>"]} -->
+<!-- cc-forge-log v1: {"skill":"side-quest","event":"side-quest-filed","followup":true,"tracking":"<owner>/<repo>#<tracking-issue>","blocked_by":["<owner>/<repo>#<originating-issue>"],"paths":["docs/side-quests/<filename>"]} -->
 
 ### 🧭 /side-quest — <short side-quest title>
 
+**Doc:** `docs/side-quests/<filename>`
 **Found:** <one line: what was discovered and why it's out of scope for the current work>
 **Tracking:** <owner>/<repo>#<tracking-issue>
 EOF

--- a/skills/side-quest/SKILL.md
+++ b/skills/side-quest/SKILL.md
@@ -88,6 +88,8 @@ Side-quest documented at `docs/side-quests/[filename]`.
 
 Back the side-quest with a real GitHub issue so it stays visible without local state.
 
+If the doc's `tracking:` frontmatter is already filled (a previous or interrupted run created the issue), skip creation and reuse that ref in Phase 4.
+
 1. Draft the tracking issue:
    - **Title:** the side-quest title from Phase 1.
    - **Body:** the doc's `## Description` section (include `## Impact / Why it matters` when it adds signal).
@@ -95,18 +97,18 @@ Back the side-quest with a real GitHub issue so it stays visible without local s
    - **Question 1:** "File this as a GitHub tracking issue?" — options **Create** (set the `preview` field to the drafted title, label `follow-up`, and body) and **Skip**.
    - **Question 2** (only when an originating issue resolved in Context Gathering): "Does this side-quest depend on the current work (#[number]) landing first?" — options **Yes** / **No**.
 3. If the user skips: leave `tracking:` empty and go to Phase 4 — the stamp still posts, covering what exists.
-4. If the user confirms, create the issue:
+4. If the user confirms, write the body below to a temp file with the Write tool, then create the issue:
+   ```markdown
+   <Description section from the doc>
+
+   Blocked by <owner>/<repo>#<originating-issue>
+   ```
    ```bash
    gh issue create \
      --repo <owner>/<repo> \
      --title "<title>" \
      --label "follow-up" \
-     --body "$(cat <<'EOF'
-   <Description section from the doc>
-
-   Blocked by <owner>/<repo>#<originating-issue>
-   EOF
-   )"
+     --body-file <temp-file>
    ```
    - Include the `Blocked by` line only when Question 2 was answered **Yes**; omit it otherwise.
    - If the command errors because the `follow-up` label doesn't exist, re-run without `--label` and tell the user the label is missing on this repo.
@@ -119,12 +121,17 @@ Back the side-quest with a real GitHub issue so it stays visible without local s
 
 ## Phase 4: Stamp the Originating Issue
 
-Skip this phase entirely if no originating issue resolved in Context Gathering (the tracking issue from Phase 3 still stands — there is just nowhere to stamp).
+What this phase does depends on the two conditions established earlier:
 
-Posting mechanics, marker encoding, confirmation posture, and failure handling are defined in [the issue-log spec](../issue-log/SKILL.md).
+| Originating issue | Tracking issue | Phase 4 behavior |
+|---|---|---|
+| resolved | created | full stamp below: `followup:true`, `tracking`, `blocked_by` (the latter only when the tracking issue carries the `Blocked by` line) |
+| resolved | skipped | stamp with only `paths` in the marker; drop the `**Tracking:**` line — record what exists |
+| not resolved | either | skip this phase entirely (the tracking issue still stands — there is just nowhere to stamp) |
 
-```bash
-gh issue comment <originating-issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
+Posting mechanics, marker encoding, confirmation posture, and failure handling are defined in [the issue-log spec](../issue-log/SKILL.md). Compose the body below, write it to a temp file with the Write tool, and post:
+
+```markdown
 <!-- cc-forge-log v1: {"skill":"side-quest","event":"side-quest-filed","followup":true,"tracking":"<owner>/<repo>#<tracking-issue>","blocked_by":["<owner>/<repo>#<originating-issue>"],"paths":["docs/side-quests/<filename>"]} -->
 
 ### 🧭 /side-quest — <short side-quest title>
@@ -132,13 +139,10 @@ gh issue comment <originating-issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
 **Doc:** `docs/side-quests/<filename>`
 **Found:** <one line: what was discovered and why it's out of scope for the current work>
 **Tracking:** <owner>/<repo>#<tracking-issue>
-EOF
-)"
 ```
-
-Adjustments before posting:
-- Include `blocked_by` only when the tracking issue's body carries the `Blocked by` line; omit the key otherwise.
-- If tracking-issue creation was skipped in Phase 3: omit `"followup":true`, `"tracking"`, and `"blocked_by"` from the marker and drop the `**Tracking:**` line — the stamp records only what exists.
+```bash
+gh issue comment <originating-issue> --repo <owner>/<repo> --body-file <temp-file>
+```
 
 ## Phase 5: Next Steps
 

--- a/skills/side-quest/SKILL.md
+++ b/skills/side-quest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: side-quest
-description: 'Document out-of-scope tasks, technical debt, or related ideas discovered during execution that should be tracked but not immediately addressed. Ties the side-quest to the current issue.'
+description: 'Document out-of-scope tasks, technical debt, or related ideas discovered during execution that should be tracked but not immediately addressed. Files a labeled GitHub tracking issue and stamps the originating issue.'
 argument-hint: "[brief description of the side quest or task]"
 ---
 
@@ -26,8 +26,9 @@ argument-hint: "[brief description of the side quest or task]"
 1. Check the current git branch by running `git rev-parse --abbrev-ref HEAD`.
 2. Extract the issue number from the branch name. The project's branch naming convention is `{prefix}/{issue-number}/{short-description}` (e.g., `feat/123/add-login` -> `123`).
 3. If an issue number is successfully extracted, use it automatically.
-4. If the branch does not contain a clear issue number and it wasn't provided in the prompt, ask the user: "What is the GitHub/Linear issue number this relates to?"
-5. Scan `docs/brainstorms/`, `docs/plans/`, or `docs/ideate/` for any recent documents that relate to this issue or current context.
+4. If the branch does not contain a clear issue number and it wasn't provided in the prompt, ask the user: "What is the GitHub/Linear issue number this relates to?" If they answer that there is none, continue without an originating issue — the doc and tracking issue are still created, but Phase 4's stamp is skipped.
+5. Run `git remote get-url origin` and parse `<owner>/<repo>` from the URL (needed for Phases 3-4).
+6. Scan `docs/brainstorms/`, `docs/plans/`, or `docs/ideate/` for any recent documents that relate to this issue or current context.
 
 ## Phase 1: Structure the Document
 
@@ -52,6 +53,7 @@ issue: #[number]
 branch: <current-branch-name>
 topic: <kebab-case-topic>
 status: pending
+tracking:
 ---
 
 # <Topic Title>
@@ -75,13 +77,68 @@ status: pending
 
 ## Phase 2: Write the File
 
-Use the Write tool to save the side-quest document to the path determined in Phase 1.
+Use the Write tool to save the side-quest document to the path determined in Phase 1. Leave `tracking:` empty — Phase 3 fills it if a tracking issue is created.
 
 Confirm to the user:
 ```text
 Side-quest documented at `docs/side-quests/[filename]`.
 ```
 
-## Phase 3: Next Steps
+## Phase 3: File the Tracking Issue
+
+Back the side-quest with a real GitHub issue so it stays visible without local state.
+
+1. Draft the tracking issue:
+   - **Title:** the side-quest title from Phase 1.
+   - **Body:** the doc's `## Description` section (include `## Impact / Why it matters` when it adds signal).
+2. Ask with a single `AskUserQuestion` call:
+   - **Question 1:** "File this as a GitHub tracking issue?" — options **Create** (set the `preview` field to the drafted title, label `follow-up`, and body) and **Skip**.
+   - **Question 2** (only when an originating issue resolved in Context Gathering): "Does this side-quest depend on the current work (#[number]) landing first?" — options **Yes** / **No**.
+3. If the user skips: leave `tracking:` empty and go to Phase 4 — the stamp still posts, covering what exists.
+4. If the user confirms, create the issue:
+   ```bash
+   gh issue create \
+     --repo <owner>/<repo> \
+     --title "<title>" \
+     --label "follow-up" \
+     --body "$(cat <<'EOF'
+   <Description section from the doc>
+
+   Blocked by <owner>/<repo>#<originating-issue>
+   EOF
+   )"
+   ```
+   - Include the `Blocked by` line only when Question 2 was answered **Yes**; omit it otherwise.
+   - If the command errors because the `follow-up` label doesn't exist, re-run without `--label` and tell the user the label is missing on this repo.
+   - Capture the tracking-issue number from the URL in the output.
+5. Update the doc's `tracking:` frontmatter to `<owner>/<repo>#<tracking-issue>` with the Edit tool.
+6. Confirm to the user:
+   ```text
+   Tracking issue created: <issue-url>
+   ```
+
+## Phase 4: Stamp the Originating Issue
+
+Skip this phase entirely if no originating issue resolved in Context Gathering (the tracking issue from Phase 3 still stands — there is just nowhere to stamp).
+
+Posting mechanics, marker encoding, confirmation posture, and failure handling are defined in [the issue-log spec](../issue-log/SKILL.md).
+
+```bash
+gh issue comment <originating-issue> --repo <owner>/<repo> --body "$(cat <<'EOF'
+<!-- cc-forge-log v1: {"skill":"side-quest","event":"side-quest-filed","followup":true,"tracking":"<owner>/<repo>#<tracking-issue>","blocked_by":["<owner>/<repo>#<originating-issue>"]} -->
+
+### 🧭 /side-quest — <short side-quest title>
+
+**Found:** <one line: what was discovered and why it's out of scope for the current work>
+**Tracking:** <owner>/<repo>#<tracking-issue>
+EOF
+)"
+```
+
+Adjustments before posting:
+- Include `blocked_by` only when the tracking issue's body carries the `Blocked by` line; omit the key otherwise.
+- If tracking-issue creation was skipped in Phase 3: omit `"followup":true`, `"tracking"`, and `"blocked_by"` from the marker and drop the `**Tracking:**` line — the stamp records only what exists.
+
+## Phase 5: Next Steps
 
 Ask the user: "Side-quest saved. Ready to return to your main task?"

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -80,17 +80,17 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
    - **On any `ln -s` failure** (permissions, disk full, cross-device), do not silently continue: note exactly which links are missing so step 11's output reflects it.
    - Whole-dir case: subdirectories created later (e.g. a new `docs/handoff/` entry) are visible automatically. Per-subdir case: a doc subdir created in the primary **after** this worktree needs its own symlink — note this in step 11's output. Removing the worktree (`git worktree remove`, which `/land` calls on merge) deletes the symlinks and leaves the primary checkout's real `docs/` untouched.
 
-10. **Post an issue-log stamp on the GitHub issue** (only if an issue number was provided). Post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
-    ```bash
-    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "$(cat <<'EOF'
+10. **Post an issue-log stamp on the GitHub issue** (only if an issue number was provided). Compose the body below, write it to a temp file with the Write tool, and post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
+    ```markdown
     <!-- cc-forge-log v1: {"skill":"tree","event":"worktree-created","paths":["{absolute-worktree-path}"]} -->
 
     ### 🌳 /tree — worktree created
 
     **Branch:** `{branch-name}`
     **Worktree:** `{absolute-worktree-path}`
-    EOF
-    )"
+    ```
+    ```bash
+    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body-file <temp-file>
     ```
 
 11. **Output next steps.** If every step-9 symlink was verified present:

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -80,9 +80,17 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
    - **On any `ln -s` failure** (permissions, disk full, cross-device), do not silently continue: note exactly which links are missing so step 11's output reflects it.
    - Whole-dir case: subdirectories created later (e.g. a new `docs/handoff/` entry) are visible automatically. Per-subdir case: a doc subdir created in the primary **after** this worktree needs its own symlink — note this in step 11's output. Removing the worktree (`git worktree remove`, which `/land` calls on merge) deletes the symlinks and leaves the primary checkout's real `docs/` untouched.
 
-10. **Post a comment on the GitHub issue** (only if an issue number was provided):
+10. **Post an issue-log stamp on the GitHub issue** (only if an issue number was provided). Post per [the issue-log spec](../issue-log/SKILL.md)'s posting rules:
     ```bash
-    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "Worktree created: \`{branch-name}\` at \`{worktree-path}\`"
+    gh issue comment $ARGUMENTS --repo <owner>/<repo> --body "$(cat <<'EOF'
+    <!-- cc-forge-log v1: {"skill":"tree","event":"worktree-created","paths":["{absolute-worktree-path}"]} -->
+
+    ### 🌳 /tree — worktree created
+
+    **Branch:** `{branch-name}`
+    **Worktree:** `{absolute-worktree-path}`
+    EOF
+    )"
     ```
 
 11. **Output next steps.** If every step-9 symlink was verified present:

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -122,33 +122,35 @@ This command takes a work document (plan, specification, or todo file) and execu
 
    **When this matters most:** Any change that touches models with callbacks, error handling with fallback/retry, or functionality exposed through multiple interfaces.
 
-   **Issue-Log Stamps** — When a completed task finishes a plan implementation unit, post a `unit-complete` stamp to the tracked issue. Resolve the issue number and post per [the issue-log spec](../issue-log/SKILL.md) (in a worktree the branch-name segment is the common case; when nothing resolves, the spec's skip applies and the loop continues unaffected).
+   **Issue-Log Stamps** — When a completed task finishes a plan implementation unit, post a `unit-complete` stamp to the tracked issue. Resolve the issue number and post per [the issue-log spec](../issue-log/SKILL.md) (in a worktree the branch-name segment is the common case; when nothing resolves, the spec's skip applies). A skipped or failed stamp never blocks marking the unit complete or continuing the loop.
 
    Stamps are per plan unit, not per task or per commit: tasks split and merge relative to units, and small related units may land in one commit — post one stamp for each plan unit that reached completion. Compose the `unit` key by re-reading that unit's checkbox heading from the plan file at stamp time (ordinal + title) — never the in-session task title. `paths` carries the plan file path. Keep the body terse: the commit carries the diff; the stamp carries the recall value. Include **Solved:** only when a real problem was solved during the unit; omit the line otherwise.
 
-   ```bash
-   gh issue comment <n> --repo <owner>/<repo> --body "$(cat <<'EOF'
+   Compose the body below, write it to a temp file with the Write tool, and post:
+
+   ```markdown
    <!-- cc-forge-log v1: {"skill":"work","event":"unit-complete","unit":"<ordinal>: <title from plan checkbox heading>","paths":["<plan file path>"]} -->
 
    ### 🔨 /work — unit <ordinal>: <title>
 
    **Did:** <one-liner: what the unit delivered>
    **Solved:** <one-liner: the problem solved — omit this line when none>
-   EOF
-   )"
+   ```
+   ```bash
+   gh issue comment <n> --repo <owner>/<repo> --body-file <temp-file>
    ```
 
    When a unit stalls and work moves on or stops, post a `unit-blocked` stamp instead — a blocked unit never receives `unit-complete`. Include `blocked_by` in the marker only when concrete refs gate the unit; drop the key otherwise:
 
-   ```bash
-   gh issue comment <n> --repo <owner>/<repo> --body "$(cat <<'EOF'
+   ```markdown
    <!-- cc-forge-log v1: {"skill":"work","event":"unit-blocked","unit":"<ordinal>: <title from plan checkbox heading>","paths":["<plan file path>"],"blocked_by":["<owner>/<repo>#<n>"]} -->
 
    ### ⚠️ /work — unit <ordinal> blocked: <title>
 
    **Blocked:** <one-liner: what gates the unit and why work moved on>
-   EOF
-   )"
+   ```
+   ```bash
+   gh issue comment <n> --repo <owner>/<repo> --body-file <temp-file>
    ```
 
 2. **Incremental Commits**

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -96,6 +96,7 @@ This command takes a work document (plan, specification, or todo file) and execu
      - Run System-Wide Test Check (see below)
      - Run tests after changes
      - Mark task as completed
+     - Stamp any completed plan unit on the issue (see below)
      - Evaluate for incremental commit (see below)
    ```
 
@@ -121,6 +122,34 @@ This command takes a work document (plan, specification, or todo file) and execu
 
    **When this matters most:** Any change that touches models with callbacks, error handling with fallback/retry, or functionality exposed through multiple interfaces.
 
+   **Issue-Log Stamps** — When a completed task finishes a plan implementation unit, post a `unit-complete` stamp to the tracked issue. Resolve the issue number and post per [the issue-log spec](../issue-log/SKILL.md) (in a worktree the branch-name segment is the common case; when nothing resolves, the spec's skip applies and the loop continues unaffected).
+
+   Stamps are per plan unit, not per task or per commit: tasks split and merge relative to units, and small related units may land in one commit — post one stamp for each plan unit that reached completion. Compose the `unit` key by re-reading that unit's checkbox heading from the plan file at stamp time (ordinal + title) — never the in-session task title. `paths` carries the plan file path. Keep the body terse: the commit carries the diff; the stamp carries the recall value. Include **Solved:** only when a real problem was solved during the unit; omit the line otherwise.
+
+   ```bash
+   gh issue comment <n> --repo <owner>/<repo> --body "$(cat <<'EOF'
+   <!-- cc-forge-log v1: {"skill":"work","event":"unit-complete","unit":"<ordinal>: <title from plan checkbox heading>","paths":["<plan file path>"]} -->
+
+   ### 🔨 /work — unit <ordinal>: <title>
+
+   **Did:** <one-liner: what the unit delivered>
+   **Solved:** <one-liner: the problem solved — omit this line when none>
+   EOF
+   )"
+   ```
+
+   When a unit stalls and work moves on or stops, post a `unit-blocked` stamp instead — a blocked unit never receives `unit-complete`. Include `blocked_by` in the marker only when concrete refs gate the unit; drop the key otherwise:
+
+   ```bash
+   gh issue comment <n> --repo <owner>/<repo> --body "$(cat <<'EOF'
+   <!-- cc-forge-log v1: {"skill":"work","event":"unit-blocked","unit":"<ordinal>: <title from plan checkbox heading>","paths":["<plan file path>"],"blocked_by":["<owner>/<repo>#<n>"]} -->
+
+   ### ⚠️ /work — unit <ordinal> blocked: <title>
+
+   **Blocked:** <one-liner: what gates the unit and why work moved on>
+   EOF
+   )"
+   ```
 
 2. **Incremental Commits**
 


### PR DESCRIPTION
Related to #57

### Primary Changes
- 📘 **Issue-log spec (v1):** new reference skill `skills/issue-log/SKILL.md` — stamp envelope, marker schema, event registry, resolution precedence, reader contract
- 🔨 **/work:** per-unit `unit-complete` / `unit-blocked` stamps; unit key read from the plan's checkbox heading
- 📋 **/plan + /brainstorm:** `plan-written` (once, at first issue availability) and `requirements-written` (when an issue is known in session)
- 🧭 **/side-quest:** files a `follow-up`-labeled tracking issue; stamps `side-quest-filed` with `tracking`/`blocked_by`
- 🚶 **/review-walk:** batch tracking issues for deferred items + `walk-complete` stamp with Status-derived counts
- 🔍 **/deep-review:** `review-written` stamp after the doc-verification gate
- 🚀 **/ship + /land:** `pr-created` stamp after PR creation; `pr-merged` marker folded into land's confirmed comment (recompose-safe)
- 🌳 **/tree + /branch-from-issue:** bare comments reformatted to envelope stamps

### Related Changes
- 🛠 **sync-workflows.sh:** skips reference-only skills (`user-invocable: false`)
- 📚 **Docs + version:** convention documented in README / CLAUDE.md / skills/CLAUDE.md; plugin → 0.2.0

---

### Test Plan

**Pre-merge Tests**
- [x] Spec worked example round-trips the anchored marker regex (scripted check)
- [x] Reader contract exercised live against #57's stamp thread (7 stamps parsed, pre-standard comment ignored)
- [x] Drift check: no inline stamp block restates a spec shared rule
- [x] Pre-commit sync-workflows run skips `issue-log`

**Post-merge Tests**
- [ ] Full plugin reload, then scratch-issue pass firing all 10 stamp events (brainstorm, plan incl. deferred Create-Issue path, tree, branch-from-issue, work incl. unit-blocked, deep-review, review-walk with an edge-heavy Status mix, side-quest, ship, land)
- [ ] `gh label create follow-up` (one-time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKzSU2J4aQacBDAxc57Hcr
