### PR TITLE
fix(skills): /tree no longer fails when another worktree owns main

### DIFF
--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -8,6 +8,7 @@ A pre-commit hook runs `scripts/sync-workflows.sh`, which regenerates `.devin/wo
 
 ## Related
 
+- **PR #60** (2026-07-24): /tree's main-sync now fetches origin/{default-branch} (remote-tracking ref only) instead of git fetch origin {default-branch}:{default-branch}, so it no longer hard-fails when another worktree has the default branch checked out; the new worktree branches off that fetched ref directly, and the git pull fast-forward for an already-main primary checkout is now additive rather than the sole fallback
 - **PR #59** (2026-07-21): issue-log stamp convention — new skills/issue-log reference spec (marker v1, event registry, reader contract) + ten skills stamp their key events onto the linked issue; posting hardened to --body-file after deep-review — [plan](docs/plans/2026-07-21-001-feat-issue-log-standard-plan.md)
 - **PR #55** (2026-07-15): add /tree, /preview, /unpreview for a git-worktree dev workflow (primary checkout stays on main; feature work in sibling worktrees), and fix /ship + /land to operate correctly from inside a worktree
 - **PR #40** (2026-06-23): /land now reconciles CLAUDE.md body prose with the merged diff (not just appends); /ship splits Test Plan into Pre-merge/Post-merge; added scripts/sync-workflows.sh

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -32,7 +32,9 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
 2. **Sync main.**
    - Run `git remote` to check if a remote exists. If none, skip this step.
    - Detect the default branch name (`main` or `master`) from `git rev-parse --abbrev-ref origin/HEAD` (strip the `origin/` prefix), falling back to `main` if that fails.
-   - `git fetch origin {default-branch}:{default-branch}`. If this fails, check whether the current branch is already `{default-branch}` (`git rev-parse --abbrev-ref HEAD`) — if so, run `git pull` instead (equivalent effect, safe since the primary checkout owns that branch). Otherwise the fetch failed for a real reason (network, auth, no `origin/{default-branch}`); report the error and stop before creating the worktree from a possibly stale ref.
+   - `git fetch origin {default-branch}`. This only updates the `origin/{default-branch}` remote-tracking ref — no `:{default-branch}` destination — so it never touches the local branch and can't collide with any worktree that has `{default-branch}` checked out, including the primary checkout itself. Step 8 branches off `origin/{default-branch}` directly, so this fetch alone is sufficient. If it fails, that's a real error (network, auth, no such remote branch); report it and stop before creating the worktree from a possibly stale ref.
+   - Additionally, if the current branch is already `{default-branch}` (`git rev-parse --abbrev-ref HEAD`), also run `git pull` — this refreshes the primary checkout's working files, a benefit the remote-tracking fetch alone doesn't provide. This is additive to the fetch above, not a substitute for it.
+   - Sanity check: run `git worktree list` and check whether any entry other than the primary checkout has `{default-branch}` itself checked out (as opposed to its own feature branch). If so, warn the user this is anomalous — normal `/tree` usage never leaves a worktree parked on the default branch — but don't block on it.
 
 3. **Resolve branch context.** `$ARGUMENTS` may or may not contain an issue number.
    - **If an issue number is provided:** detect `<owner>/<repo>` from `git remote get-url origin`, then run `gh issue view $ARGUMENTS --repo <owner>/<repo>` to get the issue title and description. **If this fails** (issue doesn't exist, wrong repo, no access), tell the user the issue number couldn't be resolved and ask whether to stop or proceed without an issue link (falling back to the no-argument path below) — never fabricate an issue title. Otherwise use the fetched title/description to determine the **prefix** and **short description**.
@@ -71,7 +73,8 @@ Before starting, use `TaskList` to find any lingering tasks and delete them all 
    - If user cancels, stop.
    - If user provides a custom name via Other, use that instead (recompute the worktree path too).
 
-8. **Create the worktree:** `git worktree add {worktree-path} -b {branch-name} {default-branch}`
+8. **Create the worktree:** `git worktree add {worktree-path} -b {branch-name} origin/{default-branch}`
+   - Branches off the fetched remote-tracking ref, not the local `{default-branch}`, so the new worktree always gets the state fetched in step 2 regardless of what the local ref points to or which worktree owns it.
    - This does not touch the primary checkout's working files or currently-checked-out branch.
 
 9. **Symlink `docs/` into the worktree.** Gitignored doc subdirs (brainstorms, plans, reviews, etc.) are not materialized by `git worktree add`, so the brainstorm/plan files this work depends on would be invisible from the worktree. Two cases, decided by what `git worktree add` produced:


### PR DESCRIPTION
### Primary Changes
- 🐛 **Fix /tree worktree sync:** git fetch origin {default-branch}:{default-branch} refused to update the local main ref whenever another worktree had it checked out, and the only fallback covered just the primary-checkout-on-main case. Now fetches origin/{default-branch} (remote-tracking only, can't collide with any worktree) and branches the new worktree off that ref directly. The git pull fast-forward for an already-main primary checkout is now additive rather than the sole escape hatch. Also added a non-blocking sanity check that warns if another worktree is anomalously parked on the default branch.

---

### Test Plan

**Pre-merge Tests**
- [ ] None (documentation/skill-instruction change, no executable code)

**Post-merge Tests**
- [ ] Run /tree from the primary checkout while another worktree has main checked out; confirm it no longer hard-fails and the new worktree branches off the fetched origin/main state

Generated with [Claude Code](https://claude.com/claude-code)