### PR TITLE
agents: pin every agent to a model family alias with explicit effort

### DIFF
--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -1,10 +1,12 @@
 # Agents
 
-Specialized subagents dispatched by skills via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model`) and a prompt body. Fully-qualified name: `forge:<category>:<agent-name>`. See [README.md](README.md) for the full catalog.
+Specialized subagents dispatched by skills via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model`, optional `effort`) and a prompt body. Fully-qualified name: `forge:<category>:<agent-name>`. See [README.md](README.md) for the full catalog.
 
 Categories: `research/` (6), `review/` (15), `test/` (1), `workflow/` (2).
 
-Model pins: all of `review/` runs `claude-sonnet-5` except `review-synthesizer` (`claude-opus-4-8`); `workflow/lint` runs `haiku`; everything else inherits the session model.
+Model pins use **bare family aliases** (`opus`, `sonnet`, `haiku`), never dated IDs — an alias tracks the latest model in its family, so pins never go stale and need no manual bumping. Every agent is pinned; none inherit. All of `review/` runs `sonnet` except `review-synthesizer` (`opus`) and `adversarial-reviewer` (`opus` + `max` — the fleet's hardest reasoning, on a conditional agent so the cost stays bounded); `workflow/lint` runs `haiku`. The rest carry an explicit `effort`, tiered by whether the work is mechanical or judgment: `sonnet` + `high` for `learnings-researcher` and `git-history-analyzer` (prescribed search-and-summarize); `opus` + `high` for `/blueprint`'s `repo-research-analyst`, `framework-docs-researcher`, `best-practices-researcher`, `spec-flow-analyzer` (output gates downstream decisions) and `test-plan-critic` (its drop list deletes tests); `opus` + `max` for `issue-intelligence-analyst` (root-cause clustering that grounds all of `/ideate`'s fan-out). See [README.md](README.md) for the full table.
+
+Caveat: an alias resolves per-provider. On the Anthropic API `opus`→Opus 5 and `sonnet`→Sonnet 5, but on Bedrock and Google Cloud's Agent Platform `sonnet` resolves to Sonnet 4.5. Set `ANTHROPIC_DEFAULT_SONNET_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` if that matters for your provider.
 
 `/deep-review` loads its reviewer roster from each project's `cc-forge.local.md`, plus an always-run set (correctness, reliability, test-coverage, learnings-researcher) and conditional agents (adversarial on large/sensitive diffs). The `python-reviewer` / `typescript-reviewer` and language-specific security/performance variants are opt-in per project stack. Synthesis is delegated to `review-synthesizer`, always-run and never part of the roster.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,8 +1,26 @@
 # Agents
 
-Specialized subagents the skills dispatch via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model`) and a prompt body. Fully-qualified name: `forge:<category>:<agent-name>`.
+Specialized subagents the skills dispatch via the `Task` tool. Each is a Markdown file with YAML frontmatter (`name`, `description`, `model`, optional `effort`) and a prompt body. Fully-qualified name: `forge:<category>:<agent-name>`.
 
-Models are pinned per agent: everything under `review/` runs `claude-sonnet-5` (1M context, opus-level review quality at lower cost) except `review-synthesizer`, which runs `claude-opus-4-8`; `workflow/lint` runs `haiku`; the rest `inherit` the session model. Pins are plain frontmatter — edit them if your org's model allowlist differs or the IDs deprecate. Note a pin also applies when *other* skills dispatch the same agent, and it overrides (even downgrades) whatever model the main session runs.
+Models are pinned per agent using **bare family aliases** (`opus`, `sonnet`, `haiku`) rather than dated model IDs. An alias always resolves to the latest model in its family, so pins track model releases automatically instead of needing a manual bump each generation.
+
+| Agents | Pin |
+|---|---|
+| all of `review/` except the synthesizer and the adversarial reviewer | `sonnet` — 1M context, opus-level review quality at lower cost |
+| `review/review-synthesizer` | `opus` — highest-judgment step in `/deep-review` |
+| `review/adversarial-reviewer` | `opus` + `effort: max` — race conditions, TOCTOU, and cascade failures are the fleet's hardest reasoning; runs only on large or sensitive diffs, so the cost is bounded |
+| `workflow/lint` | `haiku` — mechanical, fast |
+| `research/learnings-researcher` | `sonnet` + `effort: high` — deterministic grep-filter-read pipeline |
+| `research/git-history-analyzer` | `sonnet` + `effort: high` — runs prescribed git incantations and summarizes; callers supply the commands |
+| `research/repo-research-analyst`, `research/framework-docs-researcher`, `research/best-practices-researcher`, `workflow/spec-flow-analyzer` | `opus` + `effort: high` — `/blueprint`'s research fan-out, whose output gates downstream planning decisions |
+| `test/test-plan-critic` | `opus` + `effort: high` — scores every case against the diff and writes a drop list the user acts on |
+| `research/issue-intelligence-analyst` | `opus` + `effort: max` — clusters issues by root cause rather than symptom; grounds all of `/ideate`'s fan-out |
+
+No agent uses `inherit`; every model is pinned so a run's cost and quality don't shift with the session model.
+
+Pins are plain frontmatter — edit them if your org's model allowlist differs. Note a pin also applies when *other* skills dispatch the same agent, and it overrides (even downgrades) whatever model the main session runs. `effort` accepts `low`/`medium`/`high`/`xhigh`/`max` and overrides the session effort level.
+
+An alias resolves per-provider, and not every provider is current: on the Anthropic API `opus`→Opus 5 and `sonnet`→Sonnet 5, but `sonnet` resolves to Sonnet 4.6 on Claude Platform on AWS and Sonnet 4.5 on Bedrock and Google Cloud's Agent Platform. Set `ANTHROPIC_DEFAULT_SONNET_MODEL` / `ANTHROPIC_DEFAULT_OPUS_MODEL` to override, or `CLAUDE_CODE_SUBAGENT_MODEL` to force every subagent onto one model for a session.
 
 Several were ported from [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin), whose stack is Rails/Ruby. The Rails-specific language has been generalized; security and performance reviewers are split into Python and TypeScript variants to match this repo's stack.
 

--- a/agents/research/best-practices-researcher.md
+++ b/agents/research/best-practices-researcher.md
@@ -1,7 +1,8 @@
 ---
 name: best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
-model: inherit
+model: opus
+effort: high
 ---
 
 <examples>

--- a/agents/research/framework-docs-researcher.md
+++ b/agents/research/framework-docs-researcher.md
@@ -1,7 +1,8 @@
 ---
 name: framework-docs-researcher
 description: "Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns."
-model: inherit
+model: opus
+effort: high
 ---
 
 <examples>

--- a/agents/research/git-history-analyzer.md
+++ b/agents/research/git-history-analyzer.md
@@ -1,7 +1,8 @@
 ---
 name: git-history-analyzer
 description: "Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist. Use when you need historical context for code changes."
-model: inherit
+model: sonnet
+effort: high
 ---
 
 <examples>

--- a/agents/research/issue-intelligence-analyst.md
+++ b/agents/research/issue-intelligence-analyst.md
@@ -1,7 +1,8 @@
 ---
 name: issue-intelligence-analyst
 description: "Fetches and analyzes GitHub issues to surface recurring themes, pain patterns, and severity trends. Use when understanding a project's issue landscape, analyzing bug patterns for ideation, or summarizing what users are reporting."
-model: inherit
+model: opus
+effort: max
 ---
 
 <examples>

--- a/agents/research/learnings-researcher.md
+++ b/agents/research/learnings-researcher.md
@@ -1,7 +1,8 @@
 ---
 name: learnings-researcher
 description: "Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes."
-model: inherit
+model: sonnet
+effort: high
 ---
 
 <examples>

--- a/agents/research/repo-research-analyst.md
+++ b/agents/research/repo-research-analyst.md
@@ -1,7 +1,8 @@
 ---
 name: repo-research-analyst
 description: "Conducts thorough research on repository structure, documentation, conventions, and implementation patterns. Use when onboarding to a new codebase or understanding project conventions."
-model: inherit
+model: opus
+effort: high
 ---
 
 <examples>

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -1,7 +1,8 @@
 ---
 name: adversarial-reviewer
 description: "Attacks a change looking for abuse cases, race conditions, and cascade failures — the ways a determined or unlucky actor breaks it. Use on diffs of ≥50 lines or any change touching shared state, concurrency, or sensitive operations."
-model: claude-sonnet-5
+model: opus
+effort: max
 ---
 
 You are an Adversarial Reviewer. You think like an attacker and a chaos engineer at once. Your job is to **break the change** — find the input, timing, or sequence the author didn't imagine. You assume hostile users, concurrent execution, and unlucky interleavings.

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: architecture-strategist
 description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 <examples>

--- a/agents/review/code-simplicity-reviewer.md
+++ b/agents/review/code-simplicity-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplicity-reviewer
 description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 <examples>

--- a/agents/review/correctness-auditor.md
+++ b/agents/review/correctness-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: correctness-auditor
 description: "Audits code for logic bugs, broken contracts, off-by-one errors, wrong branching, and mishandled return values. Use when reviewing a change for whether it actually does what it claims."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You are a Correctness Auditor. Your single question for every line of code: **does it do what it claims, for every input it can receive?** You are not concerned with style, speed, or security — only whether the behavior is right.

--- a/agents/review/data-integrity-guardian.md
+++ b/agents/review/data-integrity-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: data-integrity-guardian
 description: "Reviews persistent-state safety: schema constraints, transaction boundaries, consistency invariants, and data-lifecycle risks. Use when a change touches the database, migrations, or any stored state that must stay consistent."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You are a Data Integrity Guardian. Your concern is the **correctness and durability of stored state** — that data is never left half-written, orphaned, contradictory, or unrecoverable. You are not reviewing in-memory logic or performance; you are guarding what survives the request.

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: pattern-recognition-specialist
 description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 <examples>

--- a/agents/review/performance-oracle-python.md
+++ b/agents/review/performance-oracle-python.md
@@ -1,7 +1,7 @@
 ---
 name: performance-oracle-python
 description: "Analyzes Python code for performance bottlenecks — algorithmic complexity, ORM query patterns, memory, async, and scalability. Use after implementing Python features or when performance concerns arise."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You find performance bottlenecks in Python before they reach production. Analyze complexity, data access, memory, and scaling.

--- a/agents/review/performance-oracle-typescript.md
+++ b/agents/review/performance-oracle-typescript.md
@@ -1,7 +1,7 @@
 ---
 name: performance-oracle-typescript
 description: "Analyzes TypeScript/JavaScript code for performance bottlenecks — algorithmic complexity, query patterns, memory, async, bundle size, and rendering. Use after implementing TS/JS features or when performance concerns arise."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You find performance bottlenecks in TypeScript/JavaScript before they reach production. Analyze complexity, data access, memory, async, and (for frontend) bundle/render cost.

--- a/agents/review/python-reviewer.md
+++ b/agents/review/python-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: python-reviewer
 description: "Reviews Python code with a high bar for Pythonic patterns, type safety, and maintainability. Use after implementing features, modifying code, or creating new Python modules."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You review Python changes for Pythonic patterns, type safety, and maintainability. Be strict on modifications to existing code; pragmatic on new isolated code.

--- a/agents/review/reliability-engineer.md
+++ b/agents/review/reliability-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: reliability-engineer
 description: "Reviews error handling, retries, timeouts, partial failures, and background-job robustness. Use when a change touches I/O, network calls, queues, or anything that can fail at runtime."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You are a Reliability Engineer. You assume **everything that can fail will fail**, and you check that the code degrades safely when it does. You are not looking for logic bugs in the happy path — you are looking for what happens when the network blips, the disk fills, the process dies mid-write, or the downstream service returns a 500.

--- a/agents/review/review-synthesizer.md
+++ b/agents/review/review-synthesizer.md
@@ -1,7 +1,7 @@
 ---
 name: review-synthesizer
 description: "Synthesizes the findings from all review agents into a prioritized, grouped review document and writes it to docs/reviews/. Use as the final step of /deep-review after every review agent has reported. Distinct from the review specialists: it does not review code — it consolidates their findings into the document."
-model: claude-opus-4-8
+model: opus
 tools: Read, Write, Glob, Grep
 ---
 

--- a/agents/review/security-sentinel-python.md
+++ b/agents/review/security-sentinel-python.md
@@ -1,7 +1,7 @@
 ---
 name: security-sentinel-python
 description: "Security audit for Python code — input validation, injection, auth/authz, secrets, and OWASP risks. Use when reviewing Python changes for security or before deployment."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You audit Python code for security vulnerabilities. Think like an attacker: where is the trust boundary, what reaches it unchecked, how is it exploited?

--- a/agents/review/security-sentinel-typescript.md
+++ b/agents/review/security-sentinel-typescript.md
@@ -1,7 +1,7 @@
 ---
 name: security-sentinel-typescript
 description: "Security audit for TypeScript/JavaScript code — input validation, injection, XSS, auth/authz, secrets, and OWASP risks. Use when reviewing TS/JS changes for security or before deployment."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You audit TypeScript/JavaScript code for security vulnerabilities. Think like an attacker: where is the trust boundary, what reaches it unchecked, how is it exploited?

--- a/agents/review/test-coverage-reviewer.md
+++ b/agents/review/test-coverage-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: test-coverage-reviewer
 description: "Reviews whether a change is adequately tested — missing cases, weak assertions, untested branches, and flaky patterns. Use after implementing a feature or fix to judge the tests that ship with it. Distinct from test-plan-critic, which scores a proposed plan; this reviews the actual test code in a diff."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You are a Test Coverage Reviewer. You evaluate the **tests that ship with a change**, not the code itself. Your question: **if this code regressed, would a test catch it?** You distinguish tests that genuinely constrain behavior from tests that merely execute lines.

--- a/agents/review/typescript-reviewer.md
+++ b/agents/review/typescript-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: typescript-reviewer
 description: "Reviews TypeScript code with a high bar for type safety, modern patterns, and maintainability. Use after implementing features, modifying code, or creating new TypeScript components."
-model: claude-sonnet-5
+model: sonnet
 ---
 
 You review TypeScript changes for type safety, modern patterns, and maintainability. Be strict on modifications to existing code; pragmatic on new isolated code.

--- a/agents/test/test-plan-critic.md
+++ b/agents/test/test-plan-critic.md
@@ -1,7 +1,8 @@
 ---
 name: test-plan-critic
 description: "Annotates a test plan file in-place with viability scores (Critical/High/Medium/Low/Negligible) by cross-referencing the diff against each test case. Appends a Drop List of low-value cases. Use as the final step in test-plan generation."
-model: inherit
+model: opus
+effort: high
 ---
 
 You are a hard-nosed QA lead who hates wasted effort. Your job is to read a test plan and a git diff, then annotate each test case with an honest viability score based on how likely that scenario is to actually surface a real bug in this specific change.

--- a/agents/workflow/spec-flow-analyzer.md
+++ b/agents/workflow/spec-flow-analyzer.md
@@ -1,7 +1,8 @@
 ---
 name: spec-flow-analyzer
 description: "Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation."
-model: inherit
+model: opus
+effort: high
 ---
 
 <examples>


### PR DESCRIPTION
### Primary Changes
- 🔗 **Family aliases replace dated model IDs:** All 24 agents now pin `opus`/`sonnet`/`haiku` instead of IDs like `claude-sonnet-5`. An alias always resolves to the latest model in its family, so pins track releases automatically. This also clears `review-synthesizer`'s stale `claude-opus-4-8` pin.
- 🎚️ **`model: inherit` retired:** No agent inherits the session model anymore, so a run's cost and quality no longer shift with how the session was launched.
- 🪶 **`sonnet` + `effort: high`:** `learnings-researcher` and `git-history-analyzer` — prescribed search-and-summarize pipelines where the caller supplies the commands.
- 🧠 **`opus` + `effort: high`:** `/blueprint`'s `repo-research-analyst`, `framework-docs-researcher`, `best-practices-researcher`, `spec-flow-analyzer` (output gates downstream planning decisions), plus `test-plan-critic` (its drop list deletes tests the user would otherwise run).
- 🔥 **`opus` + `effort: max`:** `issue-intelligence-analyst` (root-cause clustering that grounds all of `/ideate`'s fan-out) and `adversarial-reviewer` (races, TOCTOU, cascade failures — the review fleet's hardest reasoning, conditional on large or sensitive diffs so the cost stays bounded).
- 📚 **Pin policy documented:** `agents/README.md` gains a table covering all 24 agents; both it and `agents/CLAUDE.md` record why aliases beat dated IDs, note that aliases resolve per-provider (`sonnet` → Sonnet 4.6 on Claude Platform on AWS, 4.5 on Bedrock/Google Cloud), and point at `ANTHROPIC_DEFAULT_*_MODEL` and `CLAUDE_CODE_SUBAGENT_MODEL` as overrides.

---

### Test Plan

**Pre-merge Tests**
- [ ] `python3 -c "import pathlib,re; [print(p) for p in pathlib.Path('agents').rglob('*.md')]"` — every agent file's frontmatter parses, `model` is alias-only, and `effort` is one of low/medium/high/xhigh/max (validated during authoring: 24/24 pass)
- [ ] `grep -rn 'model: inherit\|claude-sonnet-5\|claude-opus-4-8' agents/*/` — returns nothing (the only remaining dated IDs are in the PR #50 changelog line, which is accurate history)

**Post-merge Tests**
- [ ] `/reload-plugins`, then confirm agents still resolve — agent frontmatter changes need a reload to take effect mid-session
- [ ] Run `/deep-review` on a diff and confirm the fleet dispatches without model-allowlist errors
- [ ] Run `/blueprint` and confirm the research fan-out dispatches at the new pins

Generated with [Claude Code](https://claude.com/claude-code)