### PR TITLE
deepen-blueprint issue stamp; grind full-90m timer + session resume

### DIFF
--- a/skills/deepen-blueprint/SKILL.md
+++ b/skills/deepen-blueprint/SKILL.md
@@ -380,6 +380,24 @@ If artifact-backed mode was used and the user did not ask to inspect the scratch
 - clean up the temporary scratch directory after the plan is safely written
 - if cleanup is not practical on the current platform, say where the artifacts were left and that they are temporary workflow output
 
+### Phase 7: Stamp the Issue
+
+Substantive changes only — a pass that changed nothing stamps nothing. Post the plan-deepened stamp per [the issue-log spec](../issue-log/SKILL.md): resolve the issue number per the spec (skip silently when nothing resolves). GitHub tracker only — when the tracker is Linear, skip with a one-line note. Compose the body below, write it to a temp file with the Write tool, and post:
+
+```markdown
+<!-- cc-forge-log v1: {"skill":"deepen-blueprint","event":"plan-deepened","paths":["docs/plans/<plan-filename>"]} -->
+
+### 🔬 /deepen-blueprint — <plan title>
+
+**Doc:** `docs/plans/<plan-filename>` — <N> sections deepened
+**Summary:** <2-3 sentences: what got stronger and why>
+**Questions resolved:** <one line per open question reclassified to resolved, with its basis; "none" if none>
+**Restructures:** <one line per structural change — units reordered or split, sections added or replaced; "none" if none>
+```
+```bash
+gh issue comment <issue-number> --repo <owner>/<repo> --body-file <temp-file>
+```
+
 ## Post-Enhancement Options
 
 If substantive changes were made, present next steps using the platform's blocking question tool when available (see Interaction Method). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.

--- a/skills/grind/SKILL.md
+++ b/skills/grind/SKILL.md
@@ -53,14 +53,14 @@ Run these checks before touching anything. Any failure stops the run — a half-
 5. **Resolve the linked issue** per [the issue-log spec](../issue-log/SKILL.md)'s issue-number resolution. Remember it as `<issue>`; it may be empty. Every stamp below skips silently when it is.
 6. **Detect the test command** for the repo (`package.json` scripts, `Makefile`, `pytest.ini`, `Cargo.toml`, etc.). It is used in exactly one place: as the merge gate for a PR that reports **no CI checks** (Phase 6). When the repo has CI, `/grind` never runs the local suite itself — though build and fix subagents still leave it green.
 7. **Detect the email transport** and announce the result. `SENDGRID_API_KEY` set in the environment → email is **on**; unset → warn now, up front: "No SENDGRID_API_KEY — terminal outcomes will be stamped and pushed, but not emailed." Either way `PushNotification` still fires, so a terminal outcome is never silent. The detection is a preflight signal; the send itself re-checks (see Notification).
-8. **Start the clock** (unless `--no-timer`): record the current time in this session's working memory. The start time is **never persisted** — not to the plan doc, not to a file — so a resumed run on a fresh process starts a fresh clock.
+8. **Record run metadata.** Capture the current time — it goes in the grind-started stamp's `**Started:**` line, and (unless `--no-timer`) starts the lifetime timer in this session's working memory. Also capture this session's id from the session context (Claude Code exposes it as the `claude.ai/code/session_…` URL in the commit-trailer guidance); the stamp's resume command is `claude --resume <session-id>` — omit that line when no id is exposed. The stamped time is log, not clock: the timer is **never read from persisted state**, so a resumed run on a fresh process starts a fresh clock.
 
 ### The Lifetime Timer
 
-The VM's process lease is ~2 hours; the disk survives, the process does not. The timer's job is to ensure no phase is ever killed mid-write. It stops the run at the last phase boundary that leaves a 30-minute buffer.
+The VM's process lease is ~2 hours; the disk survives, the process does not. The timer's job is to ensure no phase is ever killed mid-write. The run works the **full 90 minutes** — no gate fires earlier — and a phase additionally may not start unless its minimum budget fits before the 1h55m mark, so whatever is in flight when the threshold passes still finishes inside the wall.
 
-- **Stop threshold:** 1h30m elapsed.
-- **Budget gates:** before starting each phase of each slice, check elapsed time against that phase's minimum budget. If `elapsed > 1h30m − minimum`, do not start the phase — go to the stop flow (Phase 8).
+- **Stop threshold:** 1h30m elapsed. Nothing stops before it.
+- **Budget gates:** before starting each phase of each slice: if `elapsed ≥ 1h30m`, or `elapsed + minimum > 1h55m`, do not start the phase — go to the stop flow (Phase 8).
 
 | Phase | Minimum budget to start |
 |-------|------------------------|
@@ -121,6 +121,8 @@ The VM's process lease is ~2 hours; the disk survives, the process does not. The
     ### ⚙️ /grind — grinding <count> PRs
 
     **Plan:** <plan file path>
+    **Started:** <YYYY-MM-DD HH:MM local>
+    **Session:** `claude --resume <session-id>`
     **Slices:** <one line per slice: "N. <slice name> — units <list>">
     ```
     ```bash
@@ -153,7 +155,7 @@ On a **resume** (a `## PR Breakdown` table already existed), reconcile each row 
     ```
     Branching off `origin/<default-branch>` is what makes serial execution work: slice N+1's worktree contains slice N's merged code. Then symlink `docs/` from the primary checkout into the worktree (as `/tree` does), since it's gitignored and the plan lives there.
 
-17. **Dispatch the build subagent** — `Agent` with `model: "opus"`, `effort: "max"`, `subagent_type: "general-purpose"`, `run_in_background: false`. `/grind` blocks on it; there is nothing to interleave in a serial run. Budget gates cannot fire while it blocks, so the 30-minute buffer is what covers a dispatched agent overrunning its phase budget — an agent that outlasts that is malfunctioning, not slow.
+17. **Dispatch the build subagent** — `Agent` with `model: "opus"`, `effort: "max"`, `subagent_type: "general-purpose"`, `run_in_background: false`. `/grind` blocks on it; there is nothing to interleave in a serial run. Budget gates cannot fire while it blocks, so the headroom between the 1h55m fit line and the ~2h wall is what covers a dispatched agent overrunning its phase budget — an agent that outlasts that is malfunctioning, not slow.
 
     The brief must contain, and nothing may be left implicit:
     - The absolute worktree path, and the instruction to do **all** work there — never in the primary checkout.
@@ -394,7 +396,7 @@ Every terminal outcome — `grind-complete`, `grind-stopped`, `grind-blocked` �
 - **Push — always.** Call `PushNotification` with a one-line message under 200 characters: outcome, plan title, and the number that matters (`grind complete: auth-refresh — 4 PRs merged` / `grind stopped: auth-refresh — 2 of 5 slices, resume to continue` / `grind blocked: auth-refresh — red CI on #61`). No markdown. Fire it on every terminal outcome, including one where the email already went out, and including a timer stop. A skipped push (you're at the terminal, so it would be redundant) is a normal result, not a failure.
 - **Email — when configured.** `SENDGRID_API_KEY` set → one `POST https://api.sendgrid.com/v3/mail/send` with a hard timeout (`curl --max-time 30`), the key passed only as an `Authorization: Bearer` header and the body via `--data @<file>`, so the key never lands in process listings and the body never lands in shell history. Unset, or the call fails → report one line, "couldn't send notification: <reason>", and continue. Exactly one attempt, never a retry, and never any retry during a timer stop.
 - **From:** `hfritz@r-o.com` (name `Hagen Fritz`) — a verified SendGrid sender; an unverified `From:` is rejected with a 403. **Recipient:** hfritz@r-o.com. **Subject:** `[grind] <plan title>: <complete | stopped | blocked>`.
-- **Body:** the outcome in one sentence, the per-slice table (merged PRs as links), what remains (for stopped/blocked), the blocking reason and PR link (for blocked), and the resume command.
+- **Body:** the outcome in one sentence, the per-slice table (merged PRs as links), what remains (for stopped/blocked), the blocking reason and PR link (for blocked), and both resume commands: `claude --resume <session-id>` (from Phase 0; omit when no id was exposed) and `/grind <plan path>`.
 - A notification failure on either channel is never fatal, never blocks the other channel, and never blocks the exit path it rides on.
 
 ## Rules
@@ -410,7 +412,7 @@ Every terminal outcome — `grind-complete`, `grind-stopped`, `grind-blocked` �
 - **The reviewer fleet posts comments, never `--approve` or `--request-changes`.** `/grind` owns the triage decision; a blocking review state from a subagent can deadlock the merge.
 - **Triage is `/grind`'s own judgment**, never delegated, and it is recorded in the review doc's `Status:` lines and on the PR **before** the fix agent is dispatched. The fix agent receives accepted findings only.
 - **One review pass per PR.** Synthesis failures degrade (inline synthesis, then raw findings) — they never halt the run while raw findings exist, and they never trigger a second fleet.
-- **The timer is in-memory and per-invocation.** Never persist the start time; a resume starts a fresh clock. No gate sits between merge success and the end of cleanup.
+- **The timer is in-memory and per-invocation.** The grind-started stamp's `**Started:**` line is log, not clock — never read it (or any persisted time) back as timer state; a resume starts a fresh clock. No gate sits between merge success and the end of cleanup.
 - **No force-push, no pushes to `main`, no `--no-verify`, no `git add -A`** — for `/grind` or any subagent it dispatches.
 - **The plan doc is the state; GitHub and the review doc are the checkpoints.** Update the row at every transition; on resume, reconcile against `gh` and the disk rather than trusting the table.
 - **Report the real outcome.** Only claim "merged" after `gh pr view` confirms it. Red is red.

--- a/skills/issue-log/SKILL.md
+++ b/skills/issue-log/SKILL.md
@@ -64,6 +64,7 @@ Optional keys:
 |---|---|---|---|
 | brainstorm | `requirements-written` | 🧠 | Doc path, full requirements list (direct port from the doc) |
 | blueprint | `plan-written` | 📋 | Plan path, unit count, every unit enumerated with a one-sentence summary |
+| deepen-blueprint | `plan-deepened` | 🔬 | Plan path, sections-deepened count, short summary, questions resolved, major restructures |
 | tree | `worktree-created` | 🌳 | Branch, worktree path (also in `paths`) |
 | branch-from-issue | `branch-created` | 🌱 | Branch |
 | work | `unit-complete` | 🔨 | **Did** (always), **Solved** (only when a problem was solved) |
@@ -85,7 +86,7 @@ Optional keys:
 
 Event names are these exact strings. New events join this table before any skill emits them.
 
-Document-producing skills (brainstorm, blueprint, deep-review, side-quest) start the human body with a `**Doc:**` field holding the repo-relative doc path, and carry the same path in the marker's `paths`.
+Document-producing skills (brainstorm, blueprint, deepen-blueprint, deep-review, side-quest) start the human body with a `**Doc:**` field holding the repo-relative doc path, and carry the same path in the marker's `paths`.
 
 Grind's `unit-complete`/`unit-blocked` stamps are posted by its build subagent mid-build (grind blocks on that agent, so only the agent can stamp in real time). The subagent authenticates as the same `gh` login, so the reader contract's author check is unaffected; grind embeds the filled templates and encoding rules in the agent's brief rather than assuming it reads this spec.
 

--- a/skills/issue-log/SKILL.md
+++ b/skills/issue-log/SKILL.md
@@ -74,7 +74,7 @@ Optional keys:
 | side-quest | `side-quest-filed` | 🧭 | What was found, tracking-issue link (`tracking`, `followup:true`) |
 | ship | `pr-created` | 🚀 | PR link (`pr`), one-line summary |
 | land | `pr-merged` | ✅ | 2-3 sentence summary of what landed + follow-ups (`pr`) |
-| grind | `grind-started` | ⚙️ | Plan path, slice count (`slices`), one line per slice |
+| grind | `grind-started` | ⚙️ | Plan path, start time, session resume command, slice count (`slices`), one line per slice |
 | grind | `unit-complete` | 🔨 | Same shape as work's row: **Did** (always), **Solved** (only when a problem was solved) |
 | grind | `unit-blocked` | ⚠️ | **Blocked:** reason; optional `blocked_by` |
 | grind | `pr-created` | 🚀 | PR link (`pr`), one-line summary |


### PR DESCRIPTION
### Primary Changes
- 🔬 **deepen-blueprint stamps the issue:** New Phase 7 posts a `plan-deepened` stamp so a deepening pass joins brainstorm/blueprint/work in the issue work log. Carries the plan path, sections-deepened count, a short summary, the open questions it reclassified as resolved, and any structural restructures. Substantive changes only.
- ⏱️ **grind works the full 90 minutes:** The budget gates read `elapsed > 1h30m − minimum`; with review, triage, and merge all at a 25m minimum, every gate fired at 65 minutes and ended runs 25 minutes early. Gates now stop at the 1h30m threshold itself, and separately refuse to start a phase whose minimum does not fit before 1h55m — keeping in-flight work inside the ~2h VM wall.
- 🔑 **grind stamps the session resume command:** Phase 0 captures the session id alongside the start time; the `grind-started` stamp gains `**Started:**` and `**Session:** claude --resume <session-id>` lines.
- 📧 **Terminal emails name both resume paths:** Every terminal email (complete, stopped, blocked) now lists `claude --resume <session-id>` next to `/grind <plan path>`, so a run that ends early is resumable straight from the inbox.

### Related Changes
- 📖 **issue-log spec:** Registers the `plan-deepened` event, adds deepen-blueprint to the document-producing skills that lead with a `**Doc:**` field, and updates grind's `grind-started` payload row.
- 📌 **Timer invariant kept explicit:** The stamped start time is log, not clock — the rule now states it is never read back as timer state, so a resume still starts a fresh clock.

---

### Test Plan

**Pre-merge Tests**
- [x] `scripts/sync-workflows.sh` — ran via the pre-commit hook on both commits; regenerated `.devin/workflows/` with `issue-log` correctly skipped (`user-invocable: false`)
- [ ] `git diff --stat main...HEAD` — confirm only the three SKILL.md files change

**Post-merge Tests**
- [ ] Run `/deepen-blueprint` on a plan with a linked issue; confirm one `plan-deepened` stamp with the four fields, and that a no-change pass stamps nothing
- [ ] Start a `/grind` run; confirm the `grind-started` stamp carries Started and Session lines and that `claude --resume <id>` reattaches
- [ ] Confirm a timer stop past 65 minutes no longer ends early, and its email lists both resume commands

Generated with [Claude Code](https://claude.com/claude-code)